### PR TITLE
Use WM_STATE_FULLSCREEN for fullscreen under X11

### DIFF
--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -164,6 +164,8 @@ protected :
 
 private :
 
+    bool useWMFullscreen() const;
+
     ////////////////////////////////////////////////////////////
     /// \brief Switch to fullscreen mode
     ///


### PR DESCRIPTION
This adds a more functional full screen mode for X11 that doesn't block window manager shortcuts like alt-tab because it doesn't grab the input.

However it is not finished, one downside of this approach is that changing the video mode from the desktop seems to introduce some graphical issues with composition window managers, before it's merged that will either have to be fixed, or doing what games that use SDL seem to do and just upscale to the native desktop resolution (compare with how Half Life 2, Super Meat Boy and Battleblock Theatre all behave under Linux).