### PR TITLE
Added optional argument on which address to bind (socket).

### DIFF
--- a/include/SFML/Network/IpAddress.hpp
+++ b/include/SFML/Network/IpAddress.hpp
@@ -139,6 +139,17 @@ public :
     Uint32 toInteger() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Tells if it's valid address or not
+    ///
+    /// Returns a boolean indicating whether it's a valid IP
+    /// address or not. Default constructed addresses are invalid.
+    ///
+    /// \return true if valid else false
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isValid() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Get the computer's local address
     ///
     /// The local address is the address of the computer from the
@@ -182,6 +193,7 @@ public :
     // Static member data
     ////////////////////////////////////////////////////////////
     static const IpAddress None;      ///< Value representing an empty/invalid address
+    static const IpAddress Any;       ///< Value representing any (valid) address
     static const IpAddress LocalHost; ///< The "localhost" address (for connecting a computer to itself locally)
     static const IpAddress Broadcast; ///< The "broadcast" address (for sending UDP messages to everyone on a local network)
 
@@ -191,6 +203,12 @@ private :
     // Member data
     ////////////////////////////////////////////////////////////
     Uint32 m_address; ///< Address stored as an unsigned 32 bits integer
+    bool   m_valid;   ///< Flag indicating if it's valid address
+
+    ////////////////////////////////////////////////////////////
+    // Private helper functions
+    ////////////////////////////////////////////////////////////
+    Uint32 resolve(const std::string& address);
 };
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Network/IpAddress.hpp
+++ b/include/SFML/Network/IpAddress.hpp
@@ -182,7 +182,6 @@ public :
     // Static member data
     ////////////////////////////////////////////////////////////
     static const IpAddress None;      ///< Value representing an empty/invalid address
-    static const IpAddress Any;       ///< Value representing any address (used for binding)
     static const IpAddress LocalHost; ///< The "localhost" address (for connecting a computer to itself locally)
     static const IpAddress Broadcast; ///< The "broadcast" address (for sending UDP messages to everyone on a local network)
 

--- a/include/SFML/Network/IpAddress.hpp
+++ b/include/SFML/Network/IpAddress.hpp
@@ -99,7 +99,7 @@ public :
     /// This constructor uses the internal representation of
     /// the address directly. It should be used for optimization
     /// purposes, and only if you got that representation from
-    /// IpAddress::ToInteger().
+    /// IpAddress::toInteger().
     ///
     /// \param address 4 bytes of the address packed into a 32-bits integer
     ///

--- a/include/SFML/Network/IpAddress.hpp
+++ b/include/SFML/Network/IpAddress.hpp
@@ -139,17 +139,6 @@ public :
     Uint32 toInteger() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Tells if it's valid address or not
-    ///
-    /// Returns a boolean indicating whether it's a valid IP
-    /// address or not. Default constructed addresses are invalid.
-    ///
-    /// \return true if valid else false
-    ///
-    ////////////////////////////////////////////////////////////
-    bool isValid() const;
-
-    ////////////////////////////////////////////////////////////
     /// \brief Get the computer's local address
     ///
     /// The local address is the address of the computer from the
@@ -197,6 +186,66 @@ public :
     static const IpAddress LocalHost; ///< The "localhost" address (for connecting a computer to itself locally)
     static const IpAddress Broadcast; ///< The "broadcast" address (for sending UDP messages to everyone on a local network)
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of == operator to compare two IP addresses
+    ///
+    /// \param right Right operand (a IP address)
+    ///
+    /// \return True if \a *this and \a right are equal
+    ///
+    ////////////////////////////////////////////////////////////
+    bool operator ==(const IpAddress& right) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of != operator to compare two IP addresses
+    ///
+    /// \param right Right operand (a IP address)
+    ///
+    /// \return True if both \a *this and \a right are different
+    ///
+    ////////////////////////////////////////////////////////////
+    bool operator !=(const IpAddress& right) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of < operator to compare two IP addresses
+    ///
+    /// \param right Right operand (a IP address)
+    ///
+    /// \return True if \a *this is lesser than \a right
+    ///
+    ////////////////////////////////////////////////////////////
+    bool operator <(const IpAddress& right) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of > operator to compare two IP addresses
+    ///
+    /// \param right Right operand (a IP address)
+    ///
+    /// \return True if \a *this is greater than \a right
+    ///
+    ////////////////////////////////////////////////////////////
+    bool operator >(const IpAddress& right) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of <= operator to compare two IP addresses
+    ///
+    /// \param right Right operand (a IP address)
+    ///
+    /// \return True if \a *this is lesser or equal than \a right
+    ///
+    ////////////////////////////////////////////////////////////
+    bool operator <=(const IpAddress& right) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of >= operator to compare two IP addresses
+    ///
+    /// \param right Right operand (a IP address)
+    ///
+    /// \return True if \a *this is greater or equal than \a right
+    ///
+    ////////////////////////////////////////////////////////////
+    bool operator >=(const IpAddress& right) const;
+
 private :
 
     ////////////////////////////////////////////////////////////
@@ -204,78 +253,8 @@ private :
     ////////////////////////////////////////////////////////////
     Uint32 m_address; ///< Address stored as an unsigned 32 bits integer
     bool   m_valid;   ///< Flag indicating if it's valid address
-
-    ////////////////////////////////////////////////////////////
-    // Private helper functions
-    ////////////////////////////////////////////////////////////
-    Uint32 resolve(const std::string& address);
 };
 
-////////////////////////////////////////////////////////////
-/// \brief Overload of == operator to compare two IP addresses
-///
-/// \param left  Left operand (a IP address)
-/// \param right Right operand (a IP address)
-///
-/// \return True if both addresses are equal
-///
-////////////////////////////////////////////////////////////
-SFML_NETWORK_API bool operator ==(const IpAddress& left, const IpAddress& right);
-
-////////////////////////////////////////////////////////////
-/// \brief Overload of != operator to compare two IP addresses
-///
-/// \param left  Left operand (a IP address)
-/// \param right Right operand (a IP address)
-///
-/// \return True if both addresses are different
-///
-////////////////////////////////////////////////////////////
-SFML_NETWORK_API bool operator !=(const IpAddress& left, const IpAddress& right);
-
-////////////////////////////////////////////////////////////
-/// \brief Overload of < operator to compare two IP addresses
-///
-/// \param left  Left operand (a IP address)
-/// \param right Right operand (a IP address)
-///
-/// \return True if \a left is lesser than \a right
-///
-////////////////////////////////////////////////////////////
-SFML_NETWORK_API bool operator <(const IpAddress& left, const IpAddress& right);
-
-////////////////////////////////////////////////////////////
-/// \brief Overload of > operator to compare two IP addresses
-///
-/// \param left  Left operand (a IP address)
-/// \param right Right operand (a IP address)
-///
-/// \return True if \a left is greater than \a right
-///
-////////////////////////////////////////////////////////////
-SFML_NETWORK_API bool operator >(const IpAddress& left, const IpAddress& right);
-
-////////////////////////////////////////////////////////////
-/// \brief Overload of <= operator to compare two IP addresses
-///
-/// \param left  Left operand (a IP address)
-/// \param right Right operand (a IP address)
-///
-/// \return True if \a left is lesser or equal than \a right
-///
-////////////////////////////////////////////////////////////
-SFML_NETWORK_API bool operator <=(const IpAddress& left, const IpAddress& right);
-
-////////////////////////////////////////////////////////////
-/// \brief Overload of >= operator to compare two IP addresses
-///
-/// \param left  Left operand (a IP address)
-/// \param right Right operand (a IP address)
-///
-/// \return True if \a left is greater or equal than \a right
-///
-////////////////////////////////////////////////////////////
-SFML_NETWORK_API bool operator >=(const IpAddress& left, const IpAddress& right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of >> operator to extract an IP address from an input stream

--- a/include/SFML/Network/IpAddress.hpp
+++ b/include/SFML/Network/IpAddress.hpp
@@ -182,6 +182,7 @@ public :
     // Static member data
     ////////////////////////////////////////////////////////////
     static const IpAddress None;      ///< Value representing an empty/invalid address
+    static const IpAddress Any;       ///< Value representing any address (used for binding)
     static const IpAddress LocalHost; ///< The "localhost" address (for connecting a computer to itself locally)
     static const IpAddress Broadcast; ///< The "broadcast" address (for sending UDP messages to everyone on a local network)
 

--- a/include/SFML/Network/TcpListener.hpp
+++ b/include/SFML/Network/TcpListener.hpp
@@ -73,26 +73,14 @@ public :
     /// it will be stopped first and bound to the new port.
     ///
     /// \param port Port to listen for new connections
+    /// \param address Address of interface to listen
     ///
     /// \return Status code
     ///
     /// \see accept, close
     ///
     ////////////////////////////////////////////////////////////
-    Status listen(unsigned short port);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Listen on specific address
-    ///
-    /// \param port Port to listen for new connections
-    /// \param address Address on which to listen
-    ///
-    /// \return Status code
-    ///
-    /// \see listen(unsigned short port)
-    ///
-    ////////////////////////////////////////////////////////////
-    Status listen(unsigned short port, const IpAddress& address);
+    Status listen(unsigned short port, const IpAddress& address = IpAddress::Any);
 
     ////////////////////////////////////////////////////////////
     /// \brief Stop listening and close the socket

--- a/include/SFML/Network/TcpListener.hpp
+++ b/include/SFML/Network/TcpListener.hpp
@@ -79,7 +79,20 @@ public :
     /// \see accept, close
     ///
     ////////////////////////////////////////////////////////////
-    Status listen(unsigned short port, const sf::IpAddress& ip=sf::IpAddress::Any);
+    Status listen(unsigned short port);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Listen on specific address
+    ///
+    /// \param port Port to listen for new connections
+    /// \param ip Address on which to listen
+    ///
+    /// \return Status code
+    ///
+    /// \see listen
+    ///
+    ////////////////////////////////////////////////////////////
+    Status listen(unsigned short port, const IpAddress& ip);
 
     ////////////////////////////////////////////////////////////
     /// \brief Stop listening and close the socket

--- a/include/SFML/Network/TcpListener.hpp
+++ b/include/SFML/Network/TcpListener.hpp
@@ -85,14 +85,14 @@ public :
     /// \brief Listen on specific address
     ///
     /// \param port Port to listen for new connections
-    /// \param ip Address on which to listen
+    /// \param address Address on which to listen
     ///
     /// \return Status code
     ///
-    /// \see listen
+    /// \see listen(unsigned short port)
     ///
     ////////////////////////////////////////////////////////////
-    Status listen(unsigned short port, const IpAddress& ip);
+    Status listen(unsigned short port, const IpAddress& address);
 
     ////////////////////////////////////////////////////////////
     /// \brief Stop listening and close the socket

--- a/include/SFML/Network/TcpListener.hpp
+++ b/include/SFML/Network/TcpListener.hpp
@@ -30,6 +30,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Network/Export.hpp>
 #include <SFML/Network/Socket.hpp>
+#include <SFML/Network/IpAddress.hpp>
 
 
 namespace sf
@@ -78,7 +79,7 @@ public :
     /// \see accept, close
     ///
     ////////////////////////////////////////////////////////////
-    Status listen(unsigned short port);
+    Status listen(unsigned short port, const sf::IpAddress& ip=sf::IpAddress::Any);
 
     ////////////////////////////////////////////////////////////
     /// \brief Stop listening and close the socket

--- a/include/SFML/Network/UdpSocket.hpp
+++ b/include/SFML/Network/UdpSocket.hpp
@@ -30,12 +30,12 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Network/Export.hpp>
 #include <SFML/Network/Socket.hpp>
+#include <SFML/Network/IpAddress.hpp>
 #include <vector>
 
 
 namespace sf
 {
-class IpAddress;
 class Packet;
 
 ////////////////////////////////////////////////////////////
@@ -83,13 +83,14 @@ public :
     /// call getLocalPort to retrieve the chosen port.
     ///
     /// \param port Port to bind the socket to
+    /// \param address Address of interface to bind to
     ///
     /// \return Status code
     ///
     /// \see unbind, getLocalPort
     ///
     ////////////////////////////////////////////////////////////
-    Status bind(unsigned short port);
+    Status bind(unsigned short port, const IpAddress& address = sf::IpAddress::Any);
 
     ////////////////////////////////////////////////////////////
     /// \brief Unbind the socket from the local port to which it is bound

--- a/src/SFML/Network/IpAddress.cpp
+++ b/src/SFML/Network/IpAddress.cpp
@@ -64,7 +64,7 @@ namespace
             }
 
             // Not a valid address nor a host name
-            return 0;
+            return INADDR_NONE;
         }
     }
 }
@@ -74,17 +74,15 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 const IpAddress IpAddress::None;
+const IpAddress IpAddress::Any(INADDR_ANY);
 const IpAddress IpAddress::LocalHost(127, 0, 0, 1);
 const IpAddress IpAddress::Broadcast(255, 255, 255, 255);
 
 
 ////////////////////////////////////////////////////////////
 IpAddress::IpAddress() :
-m_address(0)
+m_address(INADDR_NONE)
 {
-    // We're using 0 (INADDR_ANY) instead of INADDR_NONE to represent the invalid address,
-    // because the latter is also the broadcast address (255.255.255.255); it's ok because
-    // SFML doesn't publicly use INADDR_ANY (it is always used implicitely)
 }
 
 

--- a/src/SFML/Network/IpAddress.cpp
+++ b/src/SFML/Network/IpAddress.cpp
@@ -64,7 +64,7 @@ namespace
             }
 
             // Not a valid address nor a host name
-            return INADDR_NONE;
+            return 0;
         }
     }
 }
@@ -74,15 +74,17 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 const IpAddress IpAddress::None;
-const IpAddress IpAddress::Any(INADDR_ANY);
 const IpAddress IpAddress::LocalHost(127, 0, 0, 1);
 const IpAddress IpAddress::Broadcast(255, 255, 255, 255);
 
 
 ////////////////////////////////////////////////////////////
 IpAddress::IpAddress() :
-m_address(INADDR_NONE)
+m_address(0)
 {
+    // We're using 0 (INADDR_ANY) instead of INADDR_NONE to represent the invalid address,
+    // because the latter is also the broadcast address (255.255.255.255); it's ok because
+    // SFML doesn't publicly use INADDR_ANY (it is always used implicitely)
 }
 
 

--- a/src/SFML/Network/TcpListener.cpp
+++ b/src/SFML/Network/TcpListener.cpp
@@ -61,13 +61,6 @@ unsigned short TcpListener::getLocalPort() const
 
 
 ////////////////////////////////////////////////////////////
-Socket::Status TcpListener::listen(unsigned short port)
-{
-    listen(port, IpAddress::None);
-}
-
-
-////////////////////////////////////////////////////////////
 Socket::Status TcpListener::listen(unsigned short port, const IpAddress& address)
 {
     // Create the internal socket if it doesn't exist

--- a/src/SFML/Network/TcpListener.cpp
+++ b/src/SFML/Network/TcpListener.cpp
@@ -61,7 +61,14 @@ unsigned short TcpListener::getLocalPort() const
 
 
 ////////////////////////////////////////////////////////////
-Socket::Status TcpListener::listen(unsigned short port, const sf::IpAddress& ip)
+Socket::Status TcpListener::listen(unsigned short port)
+{
+    listen(port, IpAddress::None);
+}
+
+
+////////////////////////////////////////////////////////////
+Socket::Status TcpListener::listen(unsigned short port, const IpAddress& ip)
 {
     // Create the internal socket if it doesn't exist
     create();

--- a/src/SFML/Network/TcpListener.cpp
+++ b/src/SFML/Network/TcpListener.cpp
@@ -68,14 +68,14 @@ Socket::Status TcpListener::listen(unsigned short port)
 
 
 ////////////////////////////////////////////////////////////
-Socket::Status TcpListener::listen(unsigned short port, const IpAddress& ip)
+Socket::Status TcpListener::listen(unsigned short port, const IpAddress& address)
 {
     // Create the internal socket if it doesn't exist
     create();
 
     // Bind the socket to the specified port
-    sockaddr_in address = priv::SocketImpl::createAddress(ip.toInteger(), port);
-    if (bind(getHandle(), reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1)
+    sockaddr_in addr = priv::SocketImpl::createAddress(address.toInteger(), port);
+    if (bind(getHandle(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == -1)
     {
         // Not likely to happen, but...
         err() << "Failed to bind listener socket to port " << port << std::endl;

--- a/src/SFML/Network/TcpListener.cpp
+++ b/src/SFML/Network/TcpListener.cpp
@@ -61,13 +61,13 @@ unsigned short TcpListener::getLocalPort() const
 
 
 ////////////////////////////////////////////////////////////
-Socket::Status TcpListener::listen(unsigned short port)
+Socket::Status TcpListener::listen(unsigned short port, const sf::IpAddress& ip)
 {
     // Create the internal socket if it doesn't exist
     create();
 
     // Bind the socket to the specified port
-    sockaddr_in address = priv::SocketImpl::createAddress(INADDR_ANY, port);
+    sockaddr_in address = priv::SocketImpl::createAddress(ip.toInteger(), port);
     if (bind(getHandle(), reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1)
     {
         // Not likely to happen, but...

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -118,11 +118,6 @@ unsigned short TcpSocket::getRemotePort() const
 ////////////////////////////////////////////////////////////
 Socket::Status TcpSocket::connect(const IpAddress& remoteAddress, unsigned short remotePort, Time timeout)
 {
-    if (!remoteAddress.isValid())
-    {
-        return Error;
-    }
-
     // Create the internal socket if it doesn't exist
     create();
 

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -118,6 +118,11 @@ unsigned short TcpSocket::getRemotePort() const
 ////////////////////////////////////////////////////////////
 Socket::Status TcpSocket::connect(const IpAddress& remoteAddress, unsigned short remotePort, Time timeout)
 {
+    if (!remoteAddress.isValid())
+    {
+        return Error;
+    }
+
     // Create the internal socket if it doesn't exist
     create();
 

--- a/src/SFML/Network/UdpSocket.cpp
+++ b/src/SFML/Network/UdpSocket.cpp
@@ -64,14 +64,14 @@ unsigned short UdpSocket::getLocalPort() const
 
 
 ////////////////////////////////////////////////////////////
-Socket::Status UdpSocket::bind(unsigned short port)
+Socket::Status UdpSocket::bind(unsigned short port, const IpAddress& address)
 {
     // Create the internal socket if it doesn't exist
     create();
 
     // Bind the socket
-    sockaddr_in address = priv::SocketImpl::createAddress(INADDR_ANY, port);
-    if (::bind(getHandle(), reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1)
+    sockaddr_in addr = priv::SocketImpl::createAddress(address.toInteger(), port);
+    if (::bind(getHandle(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == -1)
     {
         err() << "Failed to bind socket to port " << port << std::endl;
         return Error;


### PR DESCRIPTION
Before, SFML bound `sf::TcpListener` to all available addresses internally. This change lets you specify to which address you'd like to bind (listen).

Only been tested on Ubuntu 14.04 (clean rebuild).