### PR TITLE
Added sending a resize event when the scaling factor changes on OS X

### DIFF
--- a/src/SFML/Window/OSX/SFOpenGLView.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView.mm
@@ -266,7 +266,14 @@ BOOL isValidTextUnicode(NSEvent* event);
 {
     NSWindow* window = [self window];
     NSScreen* screen = window ? [window screen] : [NSScreen mainScreen];
+    CGFloat oldScaleFactor = m_scaleFactor;
     m_scaleFactor = [screen backingScaleFactor];
+
+    // Send a resize event if the scaling factor changed
+    if ((m_scaleFactor != oldScaleFactor) && (m_requester != 0)) {
+        NSSize newSize = [self frame].size;
+        m_requester->windowResized(newSize.width, newSize.height);
+    }
 }
 
 


### PR DESCRIPTION
This is a small bug fix that triggers a resize event when the scaling factor changes on OS X, such as when moving a window between a low-DPI display and a Retina display. The relevant forum discussion is [here](http://en.sfml-dev.org/forums/index.php?topic=17050), and a small example program that can be used to demonstrate the issue is [here](https://gist.github.com/tomgalvin594/ab67b962cf10c809cb68).