### PR TITLE
Fixed typo in JoystickImpl.cpp to prevent crash on OS X

### DIFF
--- a/src/SFML/Window/OSX/JoystickImpl.cpp
+++ b/src/SFML/Window/OSX/JoystickImpl.cpp
@@ -53,7 +53,7 @@ namespace
     std::string getDeviceString(IOHIDDeviceRef ref, CFStringRef prop, unsigned int index)
     {
         CFTypeRef typeRef = IOHIDDeviceGetProperty(ref, prop);
-        if (ref && (CFGetTypeID(typeRef) == CFStringGetTypeID()))
+        if (typeRef && (CFGetTypeID(typeRef) == CFStringGetTypeID()))
         {
             CFStringRef str = static_cast<CFStringRef>(typeRef);
             return stringFromCFString(str);
@@ -68,7 +68,7 @@ namespace
     unsigned int getDeviceUint(IOHIDDeviceRef ref, CFStringRef prop, unsigned int index)
     {
         CFTypeRef typeRef = IOHIDDeviceGetProperty(ref, prop);
-        if (ref && (CFGetTypeID(typeRef) == CFNumberGetTypeID()))
+        if (typeRef && (CFGetTypeID(typeRef) == CFNumberGetTypeID()))
         {
             SInt32 value;
             CFNumberGetValue((CFNumberRef)typeRef, kCFNumberSInt32Type, &value);


### PR DESCRIPTION
Supersedes #762.

Read for review/testing.

@executionunit, could you test it?