### PR TITLE
Relaxed cmake installation rules regarding OS X framework dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,9 +267,14 @@ if(SFML_OS_WINDOWS)
 
 elseif(SFML_OS_MACOSX)
 
-    # install the non-standard frameworks SFML depends on
-    install(DIRECTORY extlibs/libs-osx/Frameworks/sndfile.framework DESTINATION ${CMAKE_INSTALL_FRAMEWORK_PREFIX})
-    install(DIRECTORY extlibs/libs-osx/Frameworks/freetype.framework DESTINATION ${CMAKE_INSTALL_FRAMEWORK_PREFIX})
+    # install extlibs dependencies only when used
+    if("${SNDFILE_LIBRARY}" STREQUAL "${SFML_SOURCE_DIR}/extlibs/libs-osx/Frameworks/sndfile.framework")
+        install(DIRECTORY extlibs/libs-osx/Frameworks/sndfile.framework DESTINATION ${CMAKE_INSTALL_FRAMEWORK_PREFIX})
+    endif()
+
+    if("${FREETYPE_LIBRARY}" STREQUAL "${SFML_SOURCE_DIR}/extlibs/libs-osx/Frameworks/freetype.framework")
+        install(DIRECTORY extlibs/libs-osx/Frameworks/freetype.framework DESTINATION ${CMAKE_INSTALL_FRAMEWORK_PREFIX})
+    endif()
 
     # install the Xcode templates if requested
     if(SFML_INSTALL_XCODE_TEMPLATES)


### PR DESCRIPTION
This PR should ease the creation of a homebrew formula. It does not completely supersedes #620 since Xcode templates are not yet (tested and) compatible with brew file hierarchy. But I don't want to slow down the development of the SFML formula for this extra and complex feature.

Related to #620 and Homebrew/homebrew#35479

NB: #757 would have to fix some conflicts with this patch but that's not a big deal.