### PR TITLE
XCB setMouseCursor

### DIFF
--- a/cmake/Modules/FindXCB.cmake
+++ b/cmake/Modules/FindXCB.cmake
@@ -49,9 +49,9 @@ IF(NOT WIN32)
     # Find XLIB_XCB if requested
     IF(FIND_XLIB_XCB)
         FIND_PATH(XLIB_XCB_INCLUDE_DIR X11/Xlib-xcb.h)
-        FIND_LIBRARY(XLIB_XCB_LIBRARY NAMES X11-xcb libX11-xcb)
+        FIND_LIBRARY(XLIB_XCB_LIBRARY NAMES X11-xcb libX11-xcb libxcb-cursor)
 
-        SET(XLIB_XCB_LIBRARIES ${XLIB_XCB_LIBRARY})
+        SET(XLIB_XCB_LIBRARIES ${XLIB_XCB_LIBRARY} -lxcb-cursor)
         SET(XLIB_XCB_INCLUDE_DIRS ${XLIB_XCB_INCLUDE_DIR})
 
         find_package_handle_standard_args(XLIB_XCB DEFAULT_MSG

--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2014 Laurent Gomila (laurent.gom@gmail.com)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_CURSOR_HPP
+#define SFML_CURSOR_HPP
+
+namespace sf
+{	
+	enum Cursor
+    { 
+        CursorArrow, 
+	    CursorText, 
+	    CursorWait,
+	    CursorHand, 
+	    CursorCross,
+        CursorSizeHorizontal,
+        CursorSizeVertical,
+        CursorSizeALL,
+        CursorHelp,
+        CursorNo,
+    };
+}
+
+#endif

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -38,6 +38,7 @@
 #include <SFML/System/Vector2.hpp>
 #include <SFML/System/NonCopyable.hpp>
 #include <SFML/System/String.hpp>
+#include <SFML/Window/Cursor.hpp>
 
 
 namespace sf
@@ -349,6 +350,26 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorVisible(bool visible);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Show or hide the mouse cursor
+    ///
+    /// The mouse cursor is visible by default.
+    ///
+    /// \param visible True to show the mouse cursor, false to hide it
+    ///
+    ////////////////////////////////////////////////////////////
+    void setMouseCursor(Cursor cursorId);
+    
+    ////////////////////////////////////////////////////////////
+    /// \brief Show or hide the mouse cursor
+    ///
+    /// The mouse cursor is visible by default.
+    ///
+    /// \param visible True to show the mouse cursor, false to hide it
+    ///
+    ////////////////////////////////////////////////////////////
+    void setMouseCursor(unsigned int width, unsigned int height, const Uint8* pixels);
 
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable automatic key-repeat

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -32,6 +32,8 @@
 #include <SFML/Window/WindowImpl.hpp>
 #include <SFML/System/String.hpp>
 #include <X11/Xlib-xcb.h>
+#include <xcb/xcb_renderutil.h>
+#include <xcb/xcb_cursor.h>
 #include <set>
 
 
@@ -147,6 +149,22 @@ public:
     virtual void setMouseCursorVisible(bool visible);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Show or hide the mouse cursor
+    ///
+    /// \param visible True to show, false to hide
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void setMouseCursor(Cursor cursorId);
+    
+    ////////////////////////////////////////////////////////////
+    /// \brief Show or hide the mouse cursor
+    ///
+    /// \param visible True to show, false to hide
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void setMouseCursor(unsigned int width, unsigned int height, const Uint8* pixels);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Enable or disable automatic key-repeat
     ///
     /// \param enabled True to enable, false to disable
@@ -228,19 +246,23 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    ::Window                m_window;              ///< X11 structure defining our window
-    ::Display*              m_display;             ///< Pointer to the display
-    xcb_connection_t*       m_connection;          ///< Pointer to the xcb connection
-    xcb_screen_t*           m_screen;              ///< Screen identifier
-    XIM                     m_inputMethod;         ///< Input method linked to the X display
-    XIC                     m_inputContext;        ///< Input context used to get unicode input in our window
-    bool                    m_isExternal;          ///< Tell whether the window has been created externally or by SFML
-    Atom                    m_atomClose;           ///< Atom used to identify the close event
-    int                     m_oldVideoMode;        ///< Video mode in use before we switch to fullscreen
-    Cursor                  m_hiddenCursor;        ///< As X11 doesn't provide cursor hidding, we must create a transparent one
-    bool                    m_keyRepeat;           ///< Is the KeyRepeat feature enabled?
-    Vector2i                m_previousSize;        ///< Previous size of the window, to find if a ConfigureNotify event is a resize event (could be a move event only)
-    bool                    m_useSizeHints;        ///< Is the size of the window fixed with size hints?
+    ::Window                    m_window;              ///< X11 structure defining our window
+    ::Display*                  m_display;             ///< Pointer to the display
+    xcb_connection_t*           m_connection;          ///< Pointer to the xcb connection
+    xcb_screen_t*               m_screen;              ///< Screen identifier
+    XIM                         m_inputMethod;         ///< Input method linked to the X display
+    XIC                         m_inputContext;        ///< Input context used to get unicode input in our window
+    bool                        m_isExternal;          ///< Tell whether the window has been created externally or by SFML
+    Atom                        m_atomClose;           ///< Atom used to identify the close event
+    int                         m_oldVideoMode;        ///< Video mode in use before we switch to fullscreen
+    bool                        m_cursorVisible;       ///< Is the cursor visible
+    xcb_cursor_t                m_cursor;              ///< X11 mouse cursor
+    xcb_cursor_t                m_hiddenCursor;        ///< Hidden cursor saved
+    xcb_cursor_context_t*       m_cctx;                ///< Cursor context for util-cursor
+    xcb_render_pictformat_t     m_pictureFormat;       ///< XCB's picture format
+    bool                        m_keyRepeat;           ///< Is the KeyRepeat feature enabled?
+    Vector2i                    m_previousSize;        ///< Previous size of the window, to find if a ConfigureNotify event is a resize event (could be a move event only)
+    bool                        m_useSizeHints;        ///< Is the size of the window fixed with size hints?
 };
 
 } // namespace priv

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -146,6 +146,22 @@ public:
     virtual void setMouseCursorVisible(bool visible);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Show or hide the mouse cursor
+    ///
+    /// \param visible True to show, false to hide
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void setMouseCursor(Cursor cursorId);
+    
+    ////////////////////////////////////////////////////////////
+    /// \brief Show or hide the mouse cursor
+    ///
+    /// \param visible True to show, false to hide
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void setMouseCursor(unsigned int width, unsigned int height, const Uint8* pixels);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Enable or disable automatic key-repeat
     ///
     /// \param enabled True to enable, false to disable
@@ -245,7 +261,9 @@ private:
     ////////////////////////////////////////////////////////////
     HWND     m_handle;           ///< Win32 handle of the window
     LONG_PTR m_callback;         ///< Stores the original event callback function of the control
+    bool     m_cursorVisible;    ///< Is the cursor visible
     HCURSOR  m_cursor;           ///< The system cursor to display into the window
+    HCURSOR  m_hiddenCursor;     ///< Hidden cursor
     HICON    m_icon;             ///< Custom icon assigned to the window
     bool     m_keyRepeatEnabled; ///< Automatic key-repeat state for keydown events
     Vector2u m_lastSize;         ///< The last handled size of the window

--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -287,6 +287,19 @@ void Window::setMouseCursorVisible(bool visible)
         m_impl->setMouseCursorVisible(visible);
 }
 
+////////////////////////////////////////////////////////////
+void Window::setMouseCursor(Cursor cursorId)
+{
+    if (m_impl)
+        m_impl->setMouseCursor(cursorId);
+}
+
+////////////////////////////////////////////////////////////
+void Window::setMouseCursor(unsigned int width, unsigned int height, const Uint8* pixels)
+{
+    if (m_impl)
+        m_impl->setMouseCursor(width, height, pixels);
+}
 
 ////////////////////////////////////////////////////////////
 void Window::setKeyRepeatEnabled(bool enabled)

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -39,6 +39,7 @@
 #include <SFML/Window/VideoMode.hpp>
 #include <SFML/Window/WindowHandle.hpp>
 #include <SFML/Window/ContextSettings.hpp>
+#include <SFML/Window/Cursor.hpp>
 #include <queue>
 #include <set>
 
@@ -185,6 +186,22 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     virtual void setMouseCursorVisible(bool visible) = 0;
+    
+    ////////////////////////////////////////////////////////////
+    /// \brief Show or hide the mouse cursor
+    ///
+    /// \param visible True to show, false to hide
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void setMouseCursor(Cursor cursorId) = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Show or hide the mouse cursor
+    ///
+    /// \param visible True to show, false to hide
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void setMouseCursor(unsigned int width, unsigned int height, const Uint8* pixels) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable automatic key-repeat


### PR DESCRIPTION
Adds setMouseCursor() function for linux as per issue #269. Please tell me what to put for doxygen comments and anything else to change.

```
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode(800, 600), "My window");
    window.setMouseCursor(142); 

    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
                window.close();
        }
        window.clear(sf::Color::Black);
        window.display();
    }

    return 0;
}
```