### PR TITLE
Added a GlTexture abstract class. This class is used by sf::Shader instead of sf::Texture.

### DIFF
--- a/include/SFML/Graphics/GlTexture.hpp
+++ b/include/SFML/Graphics/GlTexture.hpp
@@ -1,0 +1,136 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2014 Laurent Gomila (laurent.gom@gmail.com)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_GLTEXTURE_HPP
+#define SFML_GLTEXTURE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Window/GlResource.hpp>
+
+
+namespace sf
+{
+
+////////////////////////////////////////////////////////////
+/// \brief Sampler living on the graphics card using opengl identifier.
+/// 
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API GlTexture : protected GlResource
+{
+
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    GlTexture();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    /// The destructor will clean the OpenGl Texture
+    ////////////////////////////////////////////////////////////
+    virtual ~GlTexture();
+
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the maximum texture size allowed
+    ///
+    /// This maximum size is defined by the graphics driver.
+    /// You can expect a value of 512 pixels for low-end graphics
+    /// card, and up to 8192 pixels or more for newer hardware.
+    ///
+    /// Note: The first call to this function, whether by your
+    /// code or SFML will result in a context switch.
+    ///
+    /// \return Maximum size allowed for textures
+    ///
+    ////////////////////////////////////////////////////////////
+    static unsigned int getMaximumSize();
+    
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a texture size according to hardware support
+    ///
+    /// This function checks whether the graphics driver supports
+    /// non power of two sizes or not, and adjusts the size
+    /// accordingly.
+    /// The returned size is greater than or equal to the original size.
+    ///
+    /// \param size size to convert
+    ///
+    /// \return Valid nearest size (greater than or equal to specified size)
+    ///
+    ////////////////////////////////////////////////////////////
+    static unsigned int getValidSize(unsigned int size);
+    
+    
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the OpenGl Texture Identifier
+    ///
+    /// This function return the OpenGl Texture Identifier of the Object
+    /// if the identifier is 0 the GlTexture is not valid
+    ///
+    /// \return the OpenGl Texture Identifier
+    ///
+    ////////////////////////////////////////////////////////////
+    inline unsigned int getOpenGlId() {
+      return m_texture;
+    }
+    
+    ////////////////////////////////////////////////////////////
+    /// \brief Bind a texture for rendering
+    ///
+    /// Must implement the correct OpenGL bind operation (GL_TEXTURE_1D
+    /// GL_TEXTURE_2D etc.)
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void bind() const =0;    
+
+protected:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    unsigned int m_texture;       ///< Internal texture identifier
+};
+
+} // namespace sf
+
+
+#endif // SFML_GLTEXTURE_HPP
+
+////////////////////////////////////////////////////////////
+/// \class sf::GlTexture
+/// \ingroup graphics
+///
+/// sf::GlTexture is an abstract class which must be inherited 
+/// to enable the compatibility with sf::Shader
+///
+/// \see sf::Texture sf::Shader
+///
+////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -31,6 +31,7 @@
 #include <SFML/Graphics/Export.hpp>
 #include <SFML/Graphics/Transform.hpp>
 #include <SFML/Graphics/Color.hpp>
+#include <SFML/Graphics/GlTexture.hpp>
 #include <SFML/Window/GlResource.hpp>
 #include <SFML/System/NonCopyable.hpp>
 #include <SFML/System/Vector2.hpp>
@@ -42,7 +43,6 @@
 namespace sf
 {
 class InputStream;
-class Texture;
 
 ////////////////////////////////////////////////////////////
 /// \brief Shader class (vertex and fragment)
@@ -401,14 +401,16 @@ public:
     ////////////////////////////////////////////////////////////
     void setParameter(const std::string& name, const sf::Transform& transform);
 
+    
     ////////////////////////////////////////////////////////////
     /// \brief Change a texture parameter of the shader
     ///
     /// \a name is the name of the variable to change in the shader.
-    /// The corresponding parameter in the shader must be a 2D texture
-    /// (sampler2D GLSL type).
+    /// The corresponding parameter in the shader must be a 
+    /// sampler1D, sampler2D or sampler3D GLSL type. 
     ///
     /// Example:
+    /// Using sf::Texture class
     /// \code
     /// uniform sampler2D the_texture; // this is the variable in the shader
     /// \endcode
@@ -417,21 +419,24 @@ public:
     /// ...
     /// shader.setParameter("the_texture", texture);
     /// \endcode
+    /// Using custom texture class
+    /// \code
+    /// uniform sampler1D spectrum; // example: use of audio spectrum texture 
+    /// \endcode
+    /// \code
+    /// SpectrumTexture spectrum; //Custom class that inherit GlTexture
+    /// ...
+    /// shader.setParameter("spectrum", spectrum);
+    /// \endcode
     /// It is important to note that \a texture must remain alive as long
     /// as the shader uses it, no copy is made internally.
     ///
-    /// To use the texture of the object being draw, which cannot be
-    /// known in advance, you can pass the special value
-    /// sf::Shader::CurrentTexture:
-    /// \code
-    /// shader.setParameter("the_texture", sf::Shader::CurrentTexture).
-    /// \endcode
     ///
     /// \param name    Name of the texture in the shader
     /// \param texture Texture to assign
     ///
     ////////////////////////////////////////////////////////////
-    void setParameter(const std::string& name, const Texture& texture);
+    void setParameter(const std::string& name, const GlTexture& texture);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change a texture parameter of the shader
@@ -532,7 +537,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Types
     ////////////////////////////////////////////////////////////
-    typedef std::map<int, const Texture*> TextureTable;
+    typedef std::map<int, const GlTexture*> TextureTable;
     typedef std::map<std::string, int> ParamTable;
 
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -28,9 +28,9 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Graphics/GlTexture.hpp>
 #include <SFML/Graphics/Export.hpp>
 #include <SFML/Graphics/Image.hpp>
-#include <SFML/Window/GlResource.hpp>
 
 
 namespace sf
@@ -44,7 +44,7 @@ class InputStream;
 /// \brief Image living on the graphics card that can be used for drawing
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API Texture : GlResource
+class SFML_GRAPHICS_API Texture : public GlTexture
 {
 public:
 
@@ -80,7 +80,7 @@ public:
     /// \brief Destructor
     ///
     ////////////////////////////////////////////////////////////
-    ~Texture();
+    virtual ~Texture();
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the texture
@@ -452,48 +452,33 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     static void bind(const Texture* texture, CoordinateType coordinateType = Normalized);
-
+   
     ////////////////////////////////////////////////////////////
-    /// \brief Get the maximum texture size allowed
+    /// \brief Bind a texture for rendering
     ///
-    /// This maximum size is defined by the graphics driver.
-    /// You can expect a value of 512 pixels for low-end graphics
-    /// card, and up to 8192 pixels or more for newer hardware.
+    /// This function is not part of the graphics API, it mustn't be
+    /// used when drawing SFML entities. It must be used only if you
+    /// mix sf::Texture with OpenGL code.
     ///
-    /// Note: The first call to this function, whether by your
-    /// code or SFML will result in a context switch.
+    /// If texture is valid it call glCheck(glBindTexture(GL_TEXTURE_2D, texture_id)); 
+    /// Else glCheck(glBindTexture(GL_TEXTURE_2D, 0)); 
     ///
-    /// \return Maximum size allowed for textures, in pixels
+    /// This member also apply a texture coordinates correction matrix in 
+    /// case the Texture is Y flipped
     ///
     ////////////////////////////////////////////////////////////
-    static unsigned int getMaximumSize();
-
+    virtual void bind() const;
+    
 private:
 
     friend class RenderTexture;
     friend class RenderTarget;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Get a valid image size according to hardware support
-    ///
-    /// This function checks whether the graphics driver supports
-    /// non power of two sizes or not, and adjusts the size
-    /// accordingly.
-    /// The returned size is greater than or equal to the original size.
-    ///
-    /// \param size size to convert
-    ///
-    /// \return Valid nearest size (greater than or equal to specified size)
-    ///
-    ////////////////////////////////////////////////////////////
-    static unsigned int getValidSize(unsigned int size);
-
-    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
     Vector2u     m_size;          ///< Public texture size
     Vector2u     m_actualSize;    ///< Actual texture size (can be greater than public size because of padding)
-    unsigned int m_texture;       ///< Internal texture identifier
     bool         m_isSmooth;      ///< Status of the smooth filter
     bool         m_isRepeated;    ///< Is the texture in repeat mode?
     mutable bool m_pixelsFlipped; ///< To work around the inconsistency in Y orientation

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -16,6 +16,8 @@ set(SRC
     ${SRCROOT}/GLCheck.hpp
     ${SRCROOT}/GLExtensions.hpp
     ${SRCROOT}/GLExtensions.cpp
+    ${INCROOT}/GLTexture.hpp
+    ${SRCROOT}/GLTexture.cpp
     ${SRCROOT}/Image.cpp
     ${INCROOT}/Image.hpp
     ${SRCROOT}/ImageLoader.cpp

--- a/src/SFML/Graphics/GlTexture.cpp
+++ b/src/SFML/Graphics/GlTexture.cpp
@@ -1,0 +1,114 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2014 Laurent Gomila (laurent.gom@gmail.com)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/GlTexture.hpp>
+#include <SFML/Graphics/GLCheck.hpp>
+#include <SFML/Window/Context.hpp>
+#include <SFML/System/Mutex.hpp>
+#include <SFML/System/Lock.hpp>
+#include <SFML/System/Err.hpp>
+#include <cassert>
+#include <cstring>
+
+
+namespace
+{
+    sf::Mutex mutex;
+
+    unsigned int checkMaximumTextureSize()
+    {
+        // Create a temporary context in case the user queries
+        // the size before a GlResource is created, thus
+        // initializing the shared context
+        sf::Context context;
+
+        GLint size;
+        glCheck(glGetIntegerv(GL_MAX_TEXTURE_SIZE, &size));
+
+        return static_cast<unsigned int>(size);
+    }
+}
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+GlTexture::GlTexture() :
+m_texture      (0)
+{
+
+}
+
+////////////////////////////////////////////////////////////
+GlTexture::~GlTexture()
+{
+    // Destroy the OpenGL texture
+    if (m_texture)
+    {
+        ensureGlContext();
+
+        GLuint texture = static_cast<GLuint>(m_texture);
+        glCheck(glDeleteTextures(1, &texture));
+    }
+}
+
+////////////////////////////////////////////////////////////
+unsigned int GlTexture::getMaximumSize()
+{
+    // TODO: Remove this lock when it becomes unnecessary in C++11
+    Lock lock(mutex);
+
+    static unsigned int size = checkMaximumTextureSize();
+
+    return size;
+}
+
+////////////////////////////////////////////////////////////
+unsigned int GlTexture::getValidSize(unsigned int size)
+{
+    ensureGlContext();
+
+    // Make sure that extensions are initialized
+    priv::ensureExtensionsInit();
+
+    if (GLEXT_texture_non_power_of_two)
+    {
+        // If hardware supports NPOT textures, then just return the unmodified size
+        return size;
+    }
+    else
+    {
+        // If hardware doesn't support NPOT textures, we calculate the nearest power of two
+        unsigned int powerOfTwo = 1;
+        while (powerOfTwo < size)
+            powerOfTwo *= 2;
+
+        return powerOfTwo;
+    }
+}
+
+} // namespace sf

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -395,9 +395,8 @@ void Shader::setParameter(const std::string& name, const sf::Transform& transfor
     }
 }
 
-
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const Texture& texture)
+void Shader::setParameter(const std::string& name, const GlTexture& texture)
 {
     if (m_shaderProgram)
     {
@@ -596,7 +595,7 @@ void Shader::bindTextures() const
         GLint index = static_cast<GLsizei>(i + 1);
         glCheck(glUniform1iARB(it->first, index));
         glCheck(glActiveTextureARB(GL_TEXTURE0_ARB + index));
-        Texture::bind(it->second);
+        it->second->bind();
         ++it;
     }
 


### PR DESCRIPTION
I created a AbstractClass to use with sf::Shader instead of sf::Texture because I wanted to send spectrums texture in my software. Spectrum textures are usually luminance float 1D textures.

The problem was that sf::Shader only allow to send sf::Textures (Textures in 2D in rgba format) this is really limitating ! Initially I converted my float* into a rgba array but I loosed so much precision and memory for nothing... that I decided to create a class named Sampler1D. 

The main problem with SFML is that all attributes are private ! why :'( ? 
So I needed to copy paste the sf::Shader, add my class... It was ugly.

Finnaly I propose a AbstractClass that should be named GlTexture (or GLSLSampler as you wish). Only dedicated to be used with Sf::Shader, so the advanced user can inherit from it (like me with my Sampler1D). 

sf::Texture inherit from sf::GlTexture so you can use directly sf::Texture with sf::Shader like before.

sf::GlTexture contains the Opengl Texture ID, it clean the ID in destructor (so the child class doesn't care).
The only method you must provide is void bind() const; which should call the proper glBindTexture fonction.
You also need to create the texture properly using the m_texture attribute in the child class.

I also moved static methods  int getMaximumSize(); and unsigned int getValidSize(unsigned int size); because these are not specifics to RGBA texture2D...

I tested this with my Sampler1D class and it works. I can provide the Sampler1D class but the code is not "SFML coding conventions ready", and I won't provide it if you're not asking for it.

Sorry for the really bad english.