### PR TITLE
Fixed an issue in InputImpl::getSFOpenGLViewFromSFMLWindow (see issue #782)

### DIFF
--- a/src/SFML/Window/OSX/InputImpl.mm
+++ b/src/SFML/Window/OSX/InputImpl.mm
@@ -70,9 +70,26 @@ SFOpenGLView* getSFOpenGLViewFromSFMLWindow(const Window& window)
         // Subview doesn't match ?
         if (![view isKindOfClass:[SFOpenGLView class]])
         {
-            sf::err() << "The content view is not a valid SFOpenGLView"
-                      << std::endl;
-            view = nil;
+            if([view isKindOfClass:[NSView class]])
+            {
+                NSArray* subviews = [view subviews];
+                for (NSView* subview in subviews)
+                {
+                    if ([subview isKindOfClass:[SFOpenGLView class]])
+                    {
+                        view = (SFOpenGLView*)subview;
+                        break;
+                    }
+                }
+
+            }
+            else
+            {
+                sf::err() << "The content view is not a valid SFOpenGLView"
+                          << std::endl;
+                
+                view = nil;
+            }
         }
 
     }


### PR DESCRIPTION
When a window is created with fullscreen mode (see SFWindowController::setupFullscreenViewTithMode) a NSView called masterview is created with the SFLOpenGLView added as subview of this NSView. This NSView is then set as the window's contentview. 

This means that whenever InputImp::getSFOpenGLViewFromSFMLWindow is called during fulllscreen mode it'll try to get the SFOpenGLView from the contentview which fails because it's a regular NSView, not a SFOpenGLView. This fix attempts to get the SFOpenGLView from the contentview's subviews instead of the contentview itself.