### PR TITLE
Fix for GitHub's language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 * text=auto eol=lf
 
-extlibs/**/* -text -eol
+extlibs/**/* -text -eol linguist-vendored
 src/SFML/Graphics/stb_image/**/* -text -eol
 
 *.png -text -eol


### PR DESCRIPTION
GitHub uses its [linguist](https://github.com/github/linguist) library to analyse repositories for the languages used in their source files. Based on what language occurs the most, the repository is marked as such. This leads to SFML being marked as a C library instead of a C++ library. The reason behind this is because the headers in the extlibs directory contribute a huge percentage of the overall lines of code in the repository, and they are... in C...

Not too long ago, linguist added a way for repositories to mark directories that aren't already part of their [exclusion list](https://github.com/github/linguist/blob/master/lib/linguist/vendor.yml) to be ignored.

This change will make SFML show up as a C++ library on GitHub.