### PR TITLE
Fixed an issue in Joystick::Identification

### DIFF
--- a/include/SFML/Window/Joystick.hpp
+++ b/include/SFML/Window/Joystick.hpp
@@ -75,7 +75,7 @@ public:
     ////////////////////////////////////////////////////////////
     struct Identification
     {
-        Identification();
+        SFML_WINDOW_API Identification();
 
         sf::String   name;      ///< Name of the joystick
         unsigned int vendorId;  ///< Manufacturer identifier


### PR DESCRIPTION
Joystick::Identification::Indentificat() symbol was not exported.