### PR TITLE
Mouse scrolling stuff

### DIFF
--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -102,12 +102,37 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Mouse wheel events parameters (MouseWheelMoved)
     ///
+    /// \deprecated This event is deprecated and potentially inaccurate.
+    ///             Use MouseWheelVerticalEvent instead.
+    ///
     ////////////////////////////////////////////////////////////
     struct MouseWheelEvent
     {
         int delta; ///< Number of ticks the wheel has moved (positive is up, negative is down)
         int x;     ///< X position of the mouse pointer, relative to the left of the owner window
         int y;     ///< Y position of the mouse pointer, relative to the top of the owner window
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Mouse wheel horizontal events parameters (MouseWheelHorizontalMoved)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct MouseWheelHorizontalEvent
+    {
+        float delta; ///< Number of ticks the wheel has moved (positive is left, negative is right)
+        int x;       ///< X position of the mouse pointer, relative to the left of the owner window
+        int y;       ///< Y position of the mouse pointer, relative to the top of the owner window
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Mouse wheel vertical events parameters (MouseWheelVerticalMoved)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct MouseWheelVerticalEvent
+    {
+        float delta; ///< Number of ticks the wheel has moved (positive is up, negative is down)
+        int x;       ///< X position of the mouse pointer, relative to the left of the owner window
+        int y;       ///< Y position of the mouse pointer, relative to the top of the owner window
     };
 
     ////////////////////////////////////////////////////////////
@@ -152,7 +177,7 @@ public:
         int x;               ///< X position of the touch, relative to the left of the owner window
         int y;               ///< Y position of the touch, relative to the top of the owner window
     };
-    
+
     ////////////////////////////////////////////////////////////
     /// \brief Sensor event parameters (SensorChanged)
     ///
@@ -171,30 +196,32 @@ public:
     ////////////////////////////////////////////////////////////
     enum EventType
     {
-        Closed,                 ///< The window requested to be closed (no data)
-        Resized,                ///< The window was resized (data in event.size)
-        LostFocus,              ///< The window lost the focus (no data)
-        GainedFocus,            ///< The window gained the focus (no data)
-        TextEntered,            ///< A character was entered (data in event.text)
-        KeyPressed,             ///< A key was pressed (data in event.key)
-        KeyReleased,            ///< A key was released (data in event.key)
-        MouseWheelMoved,        ///< The mouse wheel was scrolled (data in event.mouseWheel)
-        MouseButtonPressed,     ///< A mouse button was pressed (data in event.mouseButton)
-        MouseButtonReleased,    ///< A mouse button was released (data in event.mouseButton)
-        MouseMoved,             ///< The mouse cursor moved (data in event.mouseMove)
-        MouseEntered,           ///< The mouse cursor entered the area of the window (no data)
-        MouseLeft,              ///< The mouse cursor left the area of the window (no data)
-        JoystickButtonPressed,  ///< A joystick button was pressed (data in event.joystickButton)
-        JoystickButtonReleased, ///< A joystick button was released (data in event.joystickButton)
-        JoystickMoved,          ///< The joystick moved along an axis (data in event.joystickMove)
-        JoystickConnected,      ///< A joystick was connected (data in event.joystickConnect)
-        JoystickDisconnected,   ///< A joystick was disconnected (data in event.joystickConnect)
-        TouchBegan,             ///< A touch event began (data in event.touch)
-        TouchMoved,             ///< A touch moved (data in event.touch)
-        TouchEnded,             ///< A touch event ended (data in event.touch)
-        SensorChanged,          ///< A sensor value changed (data in event.sensor)
+        Closed,                    ///< The window requested to be closed (no data)
+        Resized,                   ///< The window was resized (data in event.size)
+        LostFocus,                 ///< The window lost the focus (no data)
+        GainedFocus,               ///< The window gained the focus (no data)
+        TextEntered,               ///< A character was entered (data in event.text)
+        KeyPressed,                ///< A key was pressed (data in event.key)
+        KeyReleased,               ///< A key was released (data in event.key)
+        MouseWheelMoved,           ///< The mouse wheel was scrolled (data in event.mouseWheel) (deprecated)
+        MouseWheelHorizontalMoved, ///< The mouse wheel was tilted horizontally (data in event.mouseWheelHorizontal)
+        MouseWheelVerticalMoved,   ///< The mouse wheel was scrolled vertically (data in event.mouseWheelVertical)
+        MouseButtonPressed,        ///< A mouse button was pressed (data in event.mouseButton)
+        MouseButtonReleased,       ///< A mouse button was released (data in event.mouseButton)
+        MouseMoved,                ///< The mouse cursor moved (data in event.mouseMove)
+        MouseEntered,              ///< The mouse cursor entered the area of the window (no data)
+        MouseLeft,                 ///< The mouse cursor left the area of the window (no data)
+        JoystickButtonPressed,     ///< A joystick button was pressed (data in event.joystickButton)
+        JoystickButtonReleased,    ///< A joystick button was released (data in event.joystickButton)
+        JoystickMoved,             ///< The joystick moved along an axis (data in event.joystickMove)
+        JoystickConnected,         ///< A joystick was connected (data in event.joystickConnect)
+        JoystickDisconnected,      ///< A joystick was disconnected (data in event.joystickConnect)
+        TouchBegan,                ///< A touch event began (data in event.touch)
+        TouchMoved,                ///< A touch moved (data in event.touch)
+        TouchEnded,                ///< A touch event ended (data in event.touch)
+        SensorChanged,             ///< A sensor value changed (data in event.sensor)
 
-        Count                   ///< Keep last -- the total number of event types
+        Count                      ///< Keep last -- the total number of event types
     };
 
     ////////////////////////////////////////////////////////////
@@ -204,17 +231,19 @@ public:
 
     union
     {
-        SizeEvent            size;            ///< Size event parameters (Event::Resized)
-        KeyEvent             key;             ///< Key event parameters (Event::KeyPressed, Event::KeyReleased)
-        TextEvent            text;            ///< Text event parameters (Event::TextEntered)
-        MouseMoveEvent       mouseMove;       ///< Mouse move event parameters (Event::MouseMoved)
-        MouseButtonEvent     mouseButton;     ///< Mouse button event parameters (Event::MouseButtonPressed, Event::MouseButtonReleased)
-        MouseWheelEvent      mouseWheel;      ///< Mouse wheel event parameters (Event::MouseWheelMoved)
-        JoystickMoveEvent    joystickMove;    ///< Joystick move event parameters (Event::JoystickMoved)
-        JoystickButtonEvent  joystickButton;  ///< Joystick button event parameters (Event::JoystickButtonPressed, Event::JoystickButtonReleased)
-        JoystickConnectEvent joystickConnect; ///< Joystick (dis)connect event parameters (Event::JoystickConnected, Event::JoystickDisconnected)
-        TouchEvent           touch;           ///< Touch events parameters (Event::TouchBegan, Event::TouchMoved, Event::TouchEnded)
-        SensorEvent          sensor;          ///< Sensor event parameters (Event::SensorChanged)
+        SizeEvent                 size;                 ///< Size event parameters (Event::Resized)
+        KeyEvent                  key;                  ///< Key event parameters (Event::KeyPressed, Event::KeyReleased)
+        TextEvent                 text;                 ///< Text event parameters (Event::TextEntered)
+        MouseMoveEvent            mouseMove;            ///< Mouse move event parameters (Event::MouseMoved)
+        MouseButtonEvent          mouseButton;          ///< Mouse button event parameters (Event::MouseButtonPressed, Event::MouseButtonReleased)
+        MouseWheelEvent           mouseWheel;           ///< Mouse wheel event parameters (Event::MouseWheelMoved) (deprecated)
+        MouseWheelHorizontalEvent mouseWheelHorizontal; ///< Mouse wheel horizontal event parameters (Event::MouseWheelHorizontalMoved)
+        MouseWheelVerticalEvent   mouseWheelVertical;   ///< Mouse wheel vertical event parameters (Event::MouseWheelVerticalMoved)
+        JoystickMoveEvent         joystickMove;         ///< Joystick move event parameters (Event::JoystickMoved)
+        JoystickButtonEvent       joystickButton;       ///< Joystick button event parameters (Event::JoystickButtonPressed, Event::JoystickButtonReleased)
+        JoystickConnectEvent      joystickConnect;      ///< Joystick (dis)connect event parameters (Event::JoystickConnected, Event::JoystickDisconnected)
+        TouchEvent                touch;                ///< Touch events parameters (Event::TouchBegan, Event::TouchMoved, Event::TouchEnded)
+        SensorEvent               sensor;               ///< Sensor event parameters (Event::SensorChanged)
     };
 };
 

--- a/src/SFML/Window/OSX/SFOpenGLView.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView.mm
@@ -474,7 +474,7 @@ BOOL isValidTextUnicode(NSEvent* event);
     if (m_requester != 0)
     {
         NSPoint loc = [self cursorPositionFromEvent:theEvent];
-        m_requester->mouseWheelScrolledAt([theEvent deltaY], loc.x, loc.y);
+        m_requester->mouseWheelScrolledAt([theEvent deltaX], [theEvent deltaY], loc.x, loc.y);
     }
 
     // Transmit to non-SFML responder

--- a/src/SFML/Window/OSX/WindowImplCocoa.hpp
+++ b/src/SFML/Window/OSX/WindowImplCocoa.hpp
@@ -164,12 +164,13 @@ public:
     ///
     /// Send the event to SFML WindowImpl class.
     ///
-    /// \param delta scrolling delta
+    /// \param deltaX horizontal scrolling delta
+    /// \param deltaY vertical scrolling delta
     /// \param x mouse x position
     /// \param y mouse y position
     ///
     ////////////////////////////////////////////////////////////
-    void mouseWheelScrolledAt(float delta, int x, int y);
+    void mouseWheelScrolledAt(float deltaX, float deltaY, int x, int y);
 
     ////////////////////////////////////////////////////////////
     /// \brief Mouse In Event - called by the cocoa view object

--- a/src/SFML/Window/OSX/WindowImplCocoa.mm
+++ b/src/SFML/Window/OSX/WindowImplCocoa.mm
@@ -370,15 +370,29 @@ void WindowImplCocoa::mouseMovedAt(int x, int y)
 }
 
 ////////////////////////////////////////////////////////////
-void WindowImplCocoa::mouseWheelScrolledAt(float delta, int x, int y)
+void WindowImplCocoa::mouseWheelScrolledAt(float deltaX, float deltaY, int x, int y)
 {
     Event event;
+
     event.type = Event::MouseWheelMoved;
-    event.mouseWheel.delta = delta;
+    event.mouseWheel.delta = deltaY;
     event.mouseWheel.x = x;
     event.mouseWheel.y = y;
     scaleOutXY(event.mouseWheel, m_delegate);
+    pushEvent(event);
 
+    event.type = Event::MouseWheelVerticalMoved;
+    event.mouseWheelVertical.delta = deltaY;
+    event.mouseWheelVertical.x = x;
+    event.mouseWheelVertical.y = y;
+    scaleOutXY(event.mouseWheelVertical, m_delegate);
+    pushEvent(event);
+
+    event.type = Event::MouseWheelHorizontalMoved;
+    event.mouseWheelHorizontal.delta = deltaX;
+    event.mouseWheelHorizontal.x = x;
+    event.mouseWheelHorizontal.y = y;
+    scaleOutXY(event.mouseWheelHorizontal, m_delegate);
     pushEvent(event);
 }
 

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -1154,6 +1154,7 @@ bool WindowImplX11::processEvent(xcb_generic_event_t* windowEvent)
             xcb_button_press_event_t* e = reinterpret_cast<xcb_button_press_event_t*>(windowEvent);
 
             // XXX: Why button 8 and 9?
+            // Because 4 and 5 are the vertical wheel and 6 and 7 are horizontal wheel ;)
             xcb_button_t button = e->detail;
             if ((button == XCB_BUTTON_INDEX_1) ||
                 (button == XCB_BUTTON_INDEX_2) ||
@@ -1207,10 +1208,26 @@ bool WindowImplX11::processEvent(xcb_generic_event_t* windowEvent)
             else if ((button == XCB_BUTTON_INDEX_4) || (button == XCB_BUTTON_INDEX_5))
             {
                 Event event;
+
                 event.type             = Event::MouseWheelMoved;
                 event.mouseWheel.delta = button == XCB_BUTTON_INDEX_4 ? 1 : -1;
                 event.mouseWheel.x     = e->event_x;
                 event.mouseWheel.y     = e->event_y;
+                pushEvent(event);
+
+                event.type                     = Event::MouseWheelVerticalMoved;
+                event.mouseWheelVertical.delta = button == XCB_BUTTON_INDEX_4 ? 1 : -1;
+                event.mouseWheelVertical.x     = e->event_x;
+                event.mouseWheelVertical.y     = e->event_y;
+                pushEvent(event);
+            }
+            else if ((button == 6) || (button == 7))
+            {
+                Event event;
+                event.type                       = Event::MouseWheelHorizontalMoved;
+                event.mouseWheelHorizontal.delta = button == 6 ? 1 : -1;
+                event.mouseWheelHorizontal.x     = e->event_x;
+                event.mouseWheelHorizontal.y     = e->event_y;
                 pushEvent(event);
             }
             break;


### PR DESCRIPTION
Implemented support for horizontal mouse wheel scrolling as well as high-precision scrolling on Windows and OS X. Should fix (#95).

If you're wondering why there isn't support for high-precision scrolling on Unix, it's because I spent half a day fighting with the non-existant XCB Xinput documentation only to realize that most X servers probably might not even provide high-precision values yet.

As usual, OS X stuff hasn't been tested.