### PR TITLE
Fix for the destructor of SoundBuffer. 

### DIFF
--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -65,8 +65,14 @@ m_sounds  () // don't copy the attached sounds
 ////////////////////////////////////////////////////////////
 SoundBuffer::~SoundBuffer()
 {
-    // First detach the buffer from the sounds that use it (to avoid OpenAL errors)
-    for (SoundList::const_iterator it = m_sounds.begin(); it != m_sounds.end(); ++it)
+    // To prevent the iterator from becoming invalid, move the entire buffer to another
+    // container. Otherwise calling resetBuffer would result in detachSound being
+    // called which removes the sound from the internal list.
+    SoundList sounds;
+    sounds.swap(m_sounds);
+    
+    // Detach the buffer from the sounds that use it (to avoid OpenAL errors)
+    for (SoundList::const_iterator it = sounds.begin(); it != sounds.end(); ++it)
         (*it)->resetBuffer();
 
     // Destroy the buffer


### PR DESCRIPTION
A crash appeared when a sound still had been attached at the time of destruction.
This is because the destructor iterates over all still attached sounds and calls resetBuffer for each which in return calls Sound::stop() and SoundBuffer::detach() which then removes the element from the vector. Since the destructor is iterating over this very vector, the iterator becomes invalid and calling "++" on it at the end of the loop, caused a crash.