### PR TITLE
Combined separate horizontal/vertical mouse wheel event types

### DIFF
--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -103,7 +103,7 @@ public:
     /// \brief Mouse wheel events parameters (MouseWheelMoved)
     ///
     /// \deprecated This event is deprecated and potentially inaccurate.
-    ///             Use MouseWheelVerticalEvent instead.
+    ///             Use MouseWheelScrollEvent instead.
     ///
     ////////////////////////////////////////////////////////////
     struct MouseWheelEvent
@@ -114,25 +114,15 @@ public:
     };
 
     ////////////////////////////////////////////////////////////
-    /// \brief Mouse wheel horizontal events parameters (MouseWheelHorizontalMoved)
+    /// \brief Mouse wheel events parameters (MouseWheelScrolled)
     ///
     ////////////////////////////////////////////////////////////
-    struct MouseWheelHorizontalEvent
+    struct MouseWheelScrollEvent
     {
-        float delta; ///< Number of ticks the wheel has moved (positive is left, negative is right)
-        int x;       ///< X position of the mouse pointer, relative to the left of the owner window
-        int y;       ///< Y position of the mouse pointer, relative to the top of the owner window
-    };
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Mouse wheel vertical events parameters (MouseWheelVerticalMoved)
-    ///
-    ////////////////////////////////////////////////////////////
-    struct MouseWheelVerticalEvent
-    {
-        float delta; ///< Number of ticks the wheel has moved (positive is up, negative is down)
-        int x;       ///< X position of the mouse pointer, relative to the left of the owner window
-        int y;       ///< Y position of the mouse pointer, relative to the top of the owner window
+        Mouse::Wheel wheel; ///< Which wheel (for mice with multiple ones)
+        float        delta; ///< Wheel offset (positive is up/left, negative is down/right). High-precision mice may use non-integral offsets.
+        int          x;     ///< X position of the mouse pointer, relative to the left of the owner window
+        int          y;     ///< Y position of the mouse pointer, relative to the top of the owner window
     };
 
     ////////////////////////////////////////////////////////////
@@ -196,32 +186,31 @@ public:
     ////////////////////////////////////////////////////////////
     enum EventType
     {
-        Closed,                    ///< The window requested to be closed (no data)
-        Resized,                   ///< The window was resized (data in event.size)
-        LostFocus,                 ///< The window lost the focus (no data)
-        GainedFocus,               ///< The window gained the focus (no data)
-        TextEntered,               ///< A character was entered (data in event.text)
-        KeyPressed,                ///< A key was pressed (data in event.key)
-        KeyReleased,               ///< A key was released (data in event.key)
-        MouseWheelMoved,           ///< The mouse wheel was scrolled (data in event.mouseWheel) (deprecated)
-        MouseWheelHorizontalMoved, ///< The mouse wheel was tilted horizontally (data in event.mouseWheelHorizontal)
-        MouseWheelVerticalMoved,   ///< The mouse wheel was scrolled vertically (data in event.mouseWheelVertical)
-        MouseButtonPressed,        ///< A mouse button was pressed (data in event.mouseButton)
-        MouseButtonReleased,       ///< A mouse button was released (data in event.mouseButton)
-        MouseMoved,                ///< The mouse cursor moved (data in event.mouseMove)
-        MouseEntered,              ///< The mouse cursor entered the area of the window (no data)
-        MouseLeft,                 ///< The mouse cursor left the area of the window (no data)
-        JoystickButtonPressed,     ///< A joystick button was pressed (data in event.joystickButton)
-        JoystickButtonReleased,    ///< A joystick button was released (data in event.joystickButton)
-        JoystickMoved,             ///< The joystick moved along an axis (data in event.joystickMove)
-        JoystickConnected,         ///< A joystick was connected (data in event.joystickConnect)
-        JoystickDisconnected,      ///< A joystick was disconnected (data in event.joystickConnect)
-        TouchBegan,                ///< A touch event began (data in event.touch)
-        TouchMoved,                ///< A touch moved (data in event.touch)
-        TouchEnded,                ///< A touch event ended (data in event.touch)
-        SensorChanged,             ///< A sensor value changed (data in event.sensor)
+        Closed,                 ///< The window requested to be closed (no data)
+        Resized,                ///< The window was resized (data in event.size)
+        LostFocus,              ///< The window lost the focus (no data)
+        GainedFocus,            ///< The window gained the focus (no data)
+        TextEntered,            ///< A character was entered (data in event.text)
+        KeyPressed,             ///< A key was pressed (data in event.key)
+        KeyReleased,            ///< A key was released (data in event.key)
+        MouseWheelMoved,        ///< The mouse wheel was scrolled (data in event.mouseWheel) (deprecated)
+        MouseWheelScrolled,     ///< The mouse wheel was scrolled (data in event.mouseWheelScroll)
+        MouseButtonPressed,     ///< A mouse button was pressed (data in event.mouseButton)
+        MouseButtonReleased,    ///< A mouse button was released (data in event.mouseButton)
+        MouseMoved,             ///< The mouse cursor moved (data in event.mouseMove)
+        MouseEntered,           ///< The mouse cursor entered the area of the window (no data)
+        MouseLeft,              ///< The mouse cursor left the area of the window (no data)
+        JoystickButtonPressed,  ///< A joystick button was pressed (data in event.joystickButton)
+        JoystickButtonReleased, ///< A joystick button was released (data in event.joystickButton)
+        JoystickMoved,          ///< The joystick moved along an axis (data in event.joystickMove)
+        JoystickConnected,      ///< A joystick was connected (data in event.joystickConnect)
+        JoystickDisconnected,   ///< A joystick was disconnected (data in event.joystickConnect)
+        TouchBegan,             ///< A touch event began (data in event.touch)
+        TouchMoved,             ///< A touch moved (data in event.touch)
+        TouchEnded,             ///< A touch event ended (data in event.touch)
+        SensorChanged,          ///< A sensor value changed (data in event.sensor)
 
-        Count                      ///< Keep last -- the total number of event types
+        Count                   ///< Keep last -- the total number of event types
     };
 
     ////////////////////////////////////////////////////////////
@@ -231,19 +220,18 @@ public:
 
     union
     {
-        SizeEvent                 size;                 ///< Size event parameters (Event::Resized)
-        KeyEvent                  key;                  ///< Key event parameters (Event::KeyPressed, Event::KeyReleased)
-        TextEvent                 text;                 ///< Text event parameters (Event::TextEntered)
-        MouseMoveEvent            mouseMove;            ///< Mouse move event parameters (Event::MouseMoved)
-        MouseButtonEvent          mouseButton;          ///< Mouse button event parameters (Event::MouseButtonPressed, Event::MouseButtonReleased)
-        MouseWheelEvent           mouseWheel;           ///< Mouse wheel event parameters (Event::MouseWheelMoved) (deprecated)
-        MouseWheelHorizontalEvent mouseWheelHorizontal; ///< Mouse wheel horizontal event parameters (Event::MouseWheelHorizontalMoved)
-        MouseWheelVerticalEvent   mouseWheelVertical;   ///< Mouse wheel vertical event parameters (Event::MouseWheelVerticalMoved)
-        JoystickMoveEvent         joystickMove;         ///< Joystick move event parameters (Event::JoystickMoved)
-        JoystickButtonEvent       joystickButton;       ///< Joystick button event parameters (Event::JoystickButtonPressed, Event::JoystickButtonReleased)
-        JoystickConnectEvent      joystickConnect;      ///< Joystick (dis)connect event parameters (Event::JoystickConnected, Event::JoystickDisconnected)
-        TouchEvent                touch;                ///< Touch events parameters (Event::TouchBegan, Event::TouchMoved, Event::TouchEnded)
-        SensorEvent               sensor;               ///< Sensor event parameters (Event::SensorChanged)
+        SizeEvent             size;              ///< Size event parameters (Event::Resized)
+        KeyEvent              key;               ///< Key event parameters (Event::KeyPressed, Event::KeyReleased)
+        TextEvent             text;              ///< Text event parameters (Event::TextEntered)
+        MouseMoveEvent        mouseMove;         ///< Mouse move event parameters (Event::MouseMoved)
+        MouseButtonEvent      mouseButton;       ///< Mouse button event parameters (Event::MouseButtonPressed, Event::MouseButtonReleased)
+        MouseWheelEvent       mouseWheel;        ///< Mouse wheel event parameters (Event::MouseWheelMoved) (deprecated)
+        MouseWheelScrollEvent mouseWheelScroll;  ///< Mouse wheel event parameters (Event::MouseWheelScrolled)
+        JoystickMoveEvent     joystickMove;      ///< Joystick move event parameters (Event::JoystickMoved)
+        JoystickButtonEvent   joystickButton;    ///< Joystick button event parameters (Event::JoystickButtonPressed, Event::JoystickButtonReleased)
+        JoystickConnectEvent  joystickConnect;   ///< Joystick (dis)connect event parameters (Event::JoystickConnected, Event::JoystickDisconnected)
+        TouchEvent            touch;             ///< Touch events parameters (Event::TouchBegan, Event::TouchMoved, Event::TouchEnded)
+        SensorEvent           sensor;            ///< Sensor event parameters (Event::SensorChanged)
     };
 };
 

--- a/include/SFML/Window/Mouse.hpp
+++ b/include/SFML/Window/Mouse.hpp
@@ -60,6 +60,16 @@ public:
     };
 
     ////////////////////////////////////////////////////////////
+    /// \brief Mouse wheels
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Wheel
+    {
+        VerticalWheel,  ///< The vertical mouse wheel
+        HorizontalWheel ///< The horizontal mouse wheel
+    };
+
+    ////////////////////////////////////////////////////////////
     /// \brief Check if a mouse button is pressed
     ///
     /// \param button Button to check

--- a/src/SFML/Window/OSX/WindowImplCocoa.mm
+++ b/src/SFML/Window/OSX/WindowImplCocoa.mm
@@ -381,18 +381,20 @@ void WindowImplCocoa::mouseWheelScrolledAt(float deltaX, float deltaY, int x, in
     scaleOutXY(event.mouseWheel, m_delegate);
     pushEvent(event);
 
-    event.type = Event::MouseWheelVerticalMoved;
-    event.mouseWheelVertical.delta = deltaY;
-    event.mouseWheelVertical.x = x;
-    event.mouseWheelVertical.y = y;
-    scaleOutXY(event.mouseWheelVertical, m_delegate);
+    event.type = Event::MouseWheelScrolled;
+    event.mouseWheelScroll.wheel = Mouse::VerticalWheel;
+    event.mouseWheelScroll.delta = deltaY;
+    event.mouseWheelScroll.x = x;
+    event.mouseWheelScroll.y = y;
+    scaleOutXY(event.mouseWheelScroll, m_delegate);
     pushEvent(event);
 
-    event.type = Event::MouseWheelHorizontalMoved;
-    event.mouseWheelHorizontal.delta = deltaX;
-    event.mouseWheelHorizontal.x = x;
-    event.mouseWheelHorizontal.y = y;
-    scaleOutXY(event.mouseWheelHorizontal, m_delegate);
+    event.type = Event::MouseWheelScrolled;
+    event.mouseWheelScroll.wheel = Mouse::HorizontalWheel;
+    event.mouseWheelScroll.delta = deltaX;
+    event.mouseWheelScroll.x = x;
+    event.mouseWheelScroll.y = y;
+    scaleOutXY(event.mouseWheelScroll, m_delegate);
     pushEvent(event);
 }
 

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -2127,24 +2127,26 @@ bool WindowImplX11::processEvent(xcb_generic_event_t* windowEvent)
                 Event event;
 
                 event.type             = Event::MouseWheelMoved;
-                event.mouseWheel.delta = button == XCB_BUTTON_INDEX_4 ? 1 : -1;
+                event.mouseWheel.delta = (button == XCB_BUTTON_INDEX_4) ? 1 : -1;
                 event.mouseWheel.x     = e->event_x;
                 event.mouseWheel.y     = e->event_y;
                 pushEvent(event);
 
-                event.type                     = Event::MouseWheelVerticalMoved;
-                event.mouseWheelVertical.delta = button == XCB_BUTTON_INDEX_4 ? 1 : -1;
-                event.mouseWheelVertical.x     = e->event_x;
-                event.mouseWheelVertical.y     = e->event_y;
+                event.type                   = Event::MouseWheelScrolled;
+                event.mouseWheelScroll.wheel = Mouse::VerticalWheel;
+                event.mouseWheelScroll.delta = (button == XCB_BUTTON_INDEX_4) ? 1 : -1;
+                event.mouseWheelScroll.x     = e->event_x;
+                event.mouseWheelScroll.y     = e->event_y;
                 pushEvent(event);
             }
             else if ((button == 6) || (button == 7))
             {
                 Event event;
-                event.type                       = Event::MouseWheelHorizontalMoved;
-                event.mouseWheelHorizontal.delta = button == 6 ? 1 : -1;
-                event.mouseWheelHorizontal.x     = e->event_x;
-                event.mouseWheelHorizontal.y     = e->event_y;
+                event.type                   = Event::MouseWheelScrolled;
+                event.mouseWheelScroll.wheel = Mouse::HorizontalWheel;
+                event.mouseWheelScroll.delta = (button == 6) ? 1 : -1;
+                event.mouseWheelScroll.x     = e->event_x;
+                event.mouseWheelScroll.y     = e->event_y;
                 pushEvent(event);
             }
             break;

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -665,7 +665,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             break;
         }
 
-        // Mouse wheel event
+        // Vertical mouse wheel event
         case WM_MOUSEWHEEL:
         {
             // Mouse position is in screen coordinates, convert it to window coordinates
@@ -684,16 +684,16 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             event.mouseWheel.y     = position.y;
             pushEvent(event);
 
-            event.type                     = Event::MouseWheelVerticalMoved;
-            event.mouseWheelVertical.delta = static_cast<float>(delta) / 120.f;
-            event.mouseWheelVertical.x     = position.x;
-            event.mouseWheelVertical.y     = position.y;
+            event.type                   = Event::MouseWheelScrolled;
+            event.mouseWheelScroll.wheel = Mouse::VerticalWheel;
+            event.mouseWheelScroll.delta = static_cast<float>(delta) / 120.f;
+            event.mouseWheelScroll.x     = position.x;
+            event.mouseWheelScroll.y     = position.y;
             pushEvent(event);
-
             break;
         }
 
-        // Mouse wheel event
+        // Horizontal mouse wheel event
         case WM_MOUSEHWHEEL:
         {
             // Mouse position is in screen coordinates, convert it to window coordinates
@@ -705,10 +705,11 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             Int16 delta = static_cast<Int16>(HIWORD(wParam));
 
             Event event;
-            event.type                       = Event::MouseWheelHorizontalMoved;
-            event.mouseWheelHorizontal.delta = -static_cast<float>(delta) / 120.f;
-            event.mouseWheelHorizontal.x     = position.x;
-            event.mouseWheelHorizontal.y     = position.y;
+            event.type                   = Event::MouseWheelScrolled;
+            event.mouseWheelScroll.wheel = Mouse::HorizontalWheel;
+            event.mouseWheelScroll.delta = -static_cast<float>(delta) / 120.f;
+            event.mouseWheelScroll.x     = position.x;
+            event.mouseWheelScroll.y     = position.y;
             pushEvent(event);
             break;
         }


### PR DESCRIPTION
*Continues discussion in #810.*

Suggests a change in the recently added scroll wheel API: instead of separate event types for horizontal/vertical scrolling, use one event type for both, with an additional member variable to differentiate them. I wrote some code to show the idea, however I have not thoroughly tested it (I don't even have a mouse with multiple scroll wheels). Overview:

```cpp
class Mouse
{
public:
   enum Wheel // <- new
   {
      HorizontalWheel,
      VerticalWheel,
   };
};

struct Event
{
   struct MouseWheelPreciseEvent // <- new
   { 
      float delta;
      int x;
      int y;
      Mouse::Wheel wheel;
   };

   struct MouseWheelEvent // <- deprecated
   {
      int delta;
      int x;
      int y;
   };
};
```
### Rationale

Having two identical structs is code duplication which eventually leads to combinatorial explosion. If you ever encounter a strange mouse model with a third wheel, you have to create yet another struct (and even with only two, it feels wrong to me).

Even more important, this approach is consistent to existing event APIs like `MouseButtonEvent` and `JoystickButtonEvent` which have members for the current mouse/joystick state, **and one to know which button was pressed**. Scrolling different mouse wheels are not different event types, the same way that pressing different buttons are not.

### API in the future

We should think about the future. Currently, there is a new event type called `MouseWheelPreciseMoved`, which sounds rather ugly. It is definitely a candidate for renaming to `MouseWheelMoved` in SFML 3, however that would break some code again. I don't know whether it might make more sense to extend the current `MouseWheelMoved` event with 2 new members:
```cpp
   struct MouseWheelEvent
   { 
      int delta; // <- deprecated
      int x;
      int y;
      float highPrecisionDelta; // <- new
      Mouse::Wheel wheel; // <- new
   };
```
In SFML 3, `delta` would be removed. `highPrecisionDelta` is either left as-is, or renamed to `delta` (requiring code changes). That's why I considered using a different name that makes sense on its own, e.g. `offset` or similar. The drawback of this approach is that the relation to the `delta` is not immediately clear -- but this is just for the moment.

### Minimal test snippet
```cpp
#include <SFML/Graphics.hpp>
#include <iostream>

int main()
{
	sf::RenderWindow window(sf::VideoMode(640, 480), "SFML MouseWheel Test");
	window.setFramerateLimit(20);

	while (window.isOpen())
	{
		sf::Event event;
		while (window.pollEvent(event))
		{
			if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Escape || event.type == sf::Event::Closed)
			{
				return 0;
			}
			else if (event.type == sf::Event::MouseWheelMoved)
			{
				std::cout << "[MouseWheelMoved]         delta=" << event.mouseWheel.delta << std::endl;
			}
			else if (event.type == sf::Event::MouseWheelPreciseMoved)
			{
				std::cout << "[MouseWheelPreciseMoved]  delta=" << event.mouseWheelPrecise.delta
					<< "  wheel=" << (event.mouseWheelPrecise.wheel == sf::Mouse::VerticalWheel ? "VerticalWheel" : "HorizontalWheel") << std::endl;
			}
		}

		window.clear();		
		window.display();
	}
}
```