### PR TITLE
Fixed Unix joystick stuff

### DIFF
--- a/src/SFML/Window/Unix/JoystickImpl.hpp
+++ b/src/SFML/Window/Unix/JoystickImpl.hpp
@@ -28,9 +28,8 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <linux/joystick.h>
-#include <fcntl.h>
-#include <string>
+#include <SFML/Window/JoystickImpl.hpp>
+#include <linux/input.h>
 
 
 namespace sf


### PR DESCRIPTION
Fixes  #776.

Also makes joystick handling on Unix more robust in general, with more fallbacks than before. You will need to have a really exotic set up for this not to work :grin:.

Also replaced inotify polling with a udev monitor, so the amount of polling done should be decreased, by how much depends on the system I guess.