### PR TITLE
FindSFML: Missing dependency and wrong library path

### DIFF
--- a/cmake/Modules/FindSFML.cmake
+++ b/cmake/Modules/FindSFML.cmake
@@ -240,7 +240,8 @@ if(SFML_STATIC_LIBRARIES)
 
     # macro that searches for a 3rd-party library
     macro(find_sfml_dependency output friendlyname)
-        find_library(${output} NAMES ${ARGN} PATHS ${FIND_SFML_PATHS} PATH_SUFFIXES lib)
+        # No lookup in environment variables (PATH on Windows), as they may contain wrong library versions
+        find_library(${output} NAMES ${ARGN} PATHS ${FIND_SFML_PATHS} PATH_SUFFIXES lib NO_SYSTEM_ENVIRONMENT_PATH)
         if(${${output}} STREQUAL "${output}-NOTFOUND")
             unset(output)
             set(FIND_SFML_DEPENDENCIES_NOTFOUND "${FIND_SFML_DEPENDENCIES_NOTFOUND} ${friendlyname}")

--- a/cmake/Modules/FindSFML.cmake
+++ b/cmake/Modules/FindSFML.cmake
@@ -325,10 +325,11 @@ if(SFML_STATIC_LIBRARIES)
         find_sfml_dependency(OGG_LIBRARY "Ogg" ogg)
         find_sfml_dependency(VORBIS_LIBRARY "Vorbis" vorbis)
         find_sfml_dependency(VORBISFILE_LIBRARY "VorbisFile" vorbisfile)
+        find_sfml_dependency(VORBISENC_LIBRARY "VorbisEnc" vorbisenc)
         find_sfml_dependency(FLAC_LIBRARY "FLAC" flac)
 
         # update the list
-        set(SFML_AUDIO_DEPENDENCIES ${OPENAL_LIBRARY} ${FLAC_LIBRARY} ${VORBISFILE_LIBRARY} ${VORBIS_LIBRARY} ${OGG_LIBRARY})
+        set(SFML_AUDIO_DEPENDENCIES ${OPENAL_LIBRARY} ${FLAC_LIBRARY} ${VORBISENC_LIBRARY} ${VORBISFILE_LIBRARY} ${VORBIS_LIBRARY} ${OGG_LIBRARY})
         set(SFML_DEPENDENCIES ${SFML_DEPENDENCIES} ${SFML_AUDIO_DEPENDENCIES})
     endif()
 


### PR DESCRIPTION
Two fixes for FindSFML.cmake:

1. Environment variables (e.g. PATH on Windows) are looked up early by CMake, and libraries found there are prioritized over those in SFML's own folder. To avoid paths to wrong libraries, this commit modifies the CMake `find_library()` call, such that environment variables are no longer considered as suitable paths.
See also: http://en.sfml-dev.org/forums/index.php?topic=17774

2. The dependency **libvorbisenc** is not listed in FindSFML. Thus, libraries using SFML get an incomplete `SFML_DEPENDENCIES` variable in CMake, leading to linker errors.