### PR TITLE
Bumped back the sfml-graphics OpenGL version requirement to 1.1.

### DIFF
--- a/include/SFML/Window/ContextSettings.hpp
+++ b/include/SFML/Window/ContextSettings.hpp
@@ -57,7 +57,7 @@ struct ContextSettings
     /// \param attributes   Attribute flags of the context
     ///
     ////////////////////////////////////////////////////////////
-    explicit ContextSettings(unsigned int depth = 0, unsigned int stencil = 0, unsigned int antialiasing = 0, unsigned int major = 2, unsigned int minor = 1, unsigned int attributes = Default) :
+    explicit ContextSettings(unsigned int depth = 0, unsigned int stencil = 0, unsigned int antialiasing = 0, unsigned int major = 1, unsigned int minor = 1, unsigned int attributes = Default) :
     depthBits        (depth),
     stencilBits      (stencil),
     antialiasingLevel(antialiasing),

--- a/src/SFML/Graphics/GLExtensions.cpp
+++ b/src/SFML/Graphics/GLExtensions.cpp
@@ -40,40 +40,15 @@ void ensureExtensionsInit()
     static bool initialized = false;
     if (!initialized)
     {
-        int loaded = sfogl_LoadFunctions();
+        sfogl_LoadFunctions();
 
-        if (!sfogl_IsVersionGEQ(1, 2))
+        if (!sfogl_IsVersionGEQ(1, 1))
         {
-            err() << "sfml-graphics requires support for OpenGL 1.2 or greater" << std::endl;
+            err() << "sfml-graphics requires support for OpenGL 1.1 or greater" << std::endl;
             err() << "Ensure that hardware acceleration is enabled if available" << std::endl;
-            return;
         }
 
-        if (loaded == sfogl_LOAD_FAILED)
-        {
-            err() << "Failed to initialize OpenGL 1.2 entry points, ";
-            err() << "number of functions that failed to load: " << loaded - sfogl_LOAD_SUCCEEDED << std::endl;
-            return;
-        }
-
-        bool missing = false;
-
-        if (sfogl_ext_EXT_blend_minmax == sfogl_LOAD_FAILED)
-        {
-            err() << "Required extension EXT_blend_minmax unavailable" << std::endl;
-            missing = true;
-        }
-
-        if (sfogl_ext_EXT_blend_subtract == sfogl_LOAD_FAILED)
-        {
-            err() << "Required extension EXT_blend_subtract unavailable" << std::endl;
-            missing = true;
-        }
-
-        if (!missing)
-        {
-            initialized = true;
-        }
+        initialized = true;
     }
 #endif
 }

--- a/src/SFML/Graphics/GLExtensions.hpp
+++ b/src/SFML/Graphics/GLExtensions.hpp
@@ -108,7 +108,7 @@
 
     #include <SFML/Graphics/GLLoader.hpp>
 
-    // SFML requires at a bare minimum OpenGL 1.2 capability
+    // SFML requires at a bare minimum OpenGL 1.1 capability
     // All functionality beyond that is optional
     // and has to be checked for prior to use
 
@@ -119,16 +119,20 @@
     // Extension macro first, followed by tokens then
     // functions according to the corresponding specification
 
-    // The following extensions are required.
+    // The following extensions are optional.
+
+    // Core since 1.2 - SGIS_texture_edge_clamp
+    #define GLEXT_texture_edge_clamp                  sfogl_ext_SGIS_texture_edge_clamp
+    #define GLEXT_GL_CLAMP_TO_EDGE                    GL_CLAMP_TO_EDGE_SGIS
 
     // Core since 1.2 - EXT_blend_minmax
+    #define GLEXT_blend_minmax                        sfogl_ext_EXT_blend_minmax
     #define GLEXT_glBlendEquation                     glBlendEquationEXT
     #define GLEXT_GL_FUNC_ADD                         GL_FUNC_ADD_EXT
 
     // Core since 1.2 - EXT_blend_subtract
+    #define GLEXT_blend_subtract                      sfogl_ext_EXT_blend_subtract
     #define GLEXT_GL_FUNC_SUBTRACT                    GL_FUNC_SUBTRACT_EXT
-
-    // The following extensions are optional.
 
     // Core since 1.3 - ARB_multitexture
     #define GLEXT_multitexture                        sfogl_ext_ARB_multitexture

--- a/src/SFML/Graphics/GLExtensions.txt
+++ b/src/SFML/Graphics/GLExtensions.txt
@@ -1,8 +1,9 @@
 // Created with:
 // https://bitbucket.org/KhronosGroup/glloadgen
 // Commit d143d66ac90d538ed06f806188714861b8e8e2f9
-// lua LoadGen.lua -style=pointer_c -spec=gl -version=1.2 -indent=space -prefix=sf -extfile=GLExtensions.txt GLLoader
+// lua LoadGen.lua -style=pointer_c -spec=gl -version=1.1 -indent=space -prefix=sf -extfile=GLExtensions.txt GLLoader
 
+SGIS_texture_edge_clamp
 EXT_blend_minmax
 EXT_blend_subtract
 ARB_multitexture

--- a/src/SFML/Graphics/GLLoader.cpp
+++ b/src/SFML/Graphics/GLLoader.cpp
@@ -49,6 +49,7 @@ static sf::GlFunctionPointer IntGetProcAddress(const char* name)
     return sf::Context::getFunction(name);
 }
 
+int sfogl_ext_SGIS_texture_edge_clamp = sfogl_LOAD_FAILED;
 int sfogl_ext_EXT_blend_minmax = sfogl_LOAD_FAILED;
 int sfogl_ext_EXT_blend_subtract = sfogl_LOAD_FAILED;
 int sfogl_ext_ARB_multitexture = sfogl_LOAD_FAILED;
@@ -302,28 +303,9 @@ static int Load_EXT_framebuffer_object()
     return numFailed;
 }
 
-void (CODEGEN_FUNCPTR *sf_ptrc_glBlendColor)(GLfloat, GLfloat, GLfloat, GLfloat) = NULL;
-void (CODEGEN_FUNCPTR *sf_ptrc_glBlendEquation)(GLenum) = NULL;
-void (CODEGEN_FUNCPTR *sf_ptrc_glCopyTexSubImage3D)(GLenum, GLint, GLint, GLint, GLint, GLint, GLint, GLsizei, GLsizei) = NULL;
-void (CODEGEN_FUNCPTR *sf_ptrc_glDrawRangeElements)(GLenum, GLuint, GLuint, GLsizei, GLenum, const GLvoid *) = NULL;
-void (CODEGEN_FUNCPTR *sf_ptrc_glTexImage3D)(GLenum, GLint, GLint, GLsizei, GLsizei, GLsizei, GLint, GLenum, GLenum, const GLvoid *) = NULL;
-void (CODEGEN_FUNCPTR *sf_ptrc_glTexSubImage3D)(GLenum, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLenum, GLenum, const GLvoid *) = NULL;
-
-static int Load_Version_1_2()
+static int Load_Version_1_1()
 {
     int numFailed = 0;
-    sf_ptrc_glBlendColor = (void (CODEGEN_FUNCPTR *)(GLfloat, GLfloat, GLfloat, GLfloat))IntGetProcAddress("glBlendColor");
-    if(!sf_ptrc_glBlendColor) numFailed++;
-    sf_ptrc_glBlendEquation = (void (CODEGEN_FUNCPTR *)(GLenum))IntGetProcAddress("glBlendEquation");
-    if(!sf_ptrc_glBlendEquation) numFailed++;
-    sf_ptrc_glCopyTexSubImage3D = (void (CODEGEN_FUNCPTR *)(GLenum, GLint, GLint, GLint, GLint, GLint, GLint, GLsizei, GLsizei))IntGetProcAddress("glCopyTexSubImage3D");
-    if(!sf_ptrc_glCopyTexSubImage3D) numFailed++;
-    sf_ptrc_glDrawRangeElements = (void (CODEGEN_FUNCPTR *)(GLenum, GLuint, GLuint, GLsizei, GLenum, const GLvoid *))IntGetProcAddress("glDrawRangeElements");
-    if(!sf_ptrc_glDrawRangeElements) numFailed++;
-    sf_ptrc_glTexImage3D = (void (CODEGEN_FUNCPTR *)(GLenum, GLint, GLint, GLsizei, GLsizei, GLsizei, GLint, GLenum, GLenum, const GLvoid *))IntGetProcAddress("glTexImage3D");
-    if(!sf_ptrc_glTexImage3D) numFailed++;
-    sf_ptrc_glTexSubImage3D = (void (CODEGEN_FUNCPTR *)(GLenum, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLenum, GLenum, const GLvoid *))IntGetProcAddress("glTexSubImage3D");
-    if(!sf_ptrc_glTexSubImage3D) numFailed++;
     return numFailed;
 }
 
@@ -335,7 +317,8 @@ typedef struct sfogl_StrToExtMap_s
     PFN_LOADFUNCPOINTERS LoadExtension;
 } sfogl_StrToExtMap;
 
-static sfogl_StrToExtMap ExtensionMap[11] = {
+static sfogl_StrToExtMap ExtensionMap[12] = {
+    {"GL_SGIS_texture_edge_clamp", &sfogl_ext_SGIS_texture_edge_clamp, NULL},
     {"GL_EXT_blend_minmax", &sfogl_ext_EXT_blend_minmax, Load_EXT_blend_minmax},
     {"GL_EXT_blend_subtract", &sfogl_ext_EXT_blend_subtract, NULL},
     {"GL_ARB_multitexture", &sfogl_ext_ARB_multitexture, Load_ARB_multitexture},
@@ -349,7 +332,7 @@ static sfogl_StrToExtMap ExtensionMap[11] = {
     {"GL_EXT_framebuffer_object", &sfogl_ext_EXT_framebuffer_object, Load_EXT_framebuffer_object}
 };
 
-static int g_extensionMapSize = 11;
+static int g_extensionMapSize = 12;
 
 static sfogl_StrToExtMap *FindExtEntry(const char *extensionName)
 {
@@ -366,6 +349,7 @@ static sfogl_StrToExtMap *FindExtEntry(const char *extensionName)
 
 static void ClearExtensionVars()
 {
+    sfogl_ext_SGIS_texture_edge_clamp = sfogl_LOAD_FAILED;
     sfogl_ext_EXT_blend_minmax = sfogl_LOAD_FAILED;
     sfogl_ext_EXT_blend_subtract = sfogl_LOAD_FAILED;
     sfogl_ext_ARB_multitexture = sfogl_LOAD_FAILED;
@@ -480,7 +464,7 @@ int sfogl_LoadFunctions()
         }
     }
 
-    numFailed = Load_Version_1_2();
+    numFailed = Load_Version_1_1();
 
     if(numFailed == 0)
         return sfogl_LOAD_SUCCEEDED;

--- a/src/SFML/Graphics/GLLoader.hpp
+++ b/src/SFML/Graphics/GLLoader.hpp
@@ -173,6 +173,7 @@ typedef GLintptr GLvdpauSurfaceNV;
 extern "C" {
 #endif /*__cplusplus*/
 
+extern int sfogl_ext_SGIS_texture_edge_clamp;
 extern int sfogl_ext_EXT_blend_minmax;
 extern int sfogl_ext_EXT_blend_subtract;
 extern int sfogl_ext_ARB_multitexture;
@@ -184,6 +185,8 @@ extern int sfogl_ext_ARB_fragment_shader;
 extern int sfogl_ext_ARB_texture_non_power_of_two;
 extern int sfogl_ext_EXT_blend_equation_separate;
 extern int sfogl_ext_EXT_framebuffer_object;
+
+#define GL_CLAMP_TO_EDGE_SGIS 0x812F
 
 #define GL_BLEND_EQUATION_EXT 0x8009
 #define GL_FUNC_ADD_EXT 0x8006
@@ -781,48 +784,6 @@ extern int sfogl_ext_EXT_framebuffer_object;
 #define GL_ZOOM_X 0x0D16
 #define GL_ZOOM_Y 0x0D17
 
-#define GL_ALIASED_LINE_WIDTH_RANGE 0x846E
-#define GL_ALIASED_POINT_SIZE_RANGE 0x846D
-#define GL_BGR 0x80E0
-#define GL_BGRA 0x80E1
-#define GL_CLAMP_TO_EDGE 0x812F
-#define GL_LIGHT_MODEL_COLOR_CONTROL 0x81F8
-#define GL_MAX_3D_TEXTURE_SIZE 0x8073
-#define GL_MAX_ELEMENTS_INDICES 0x80E9
-#define GL_MAX_ELEMENTS_VERTICES 0x80E8
-#define GL_PACK_IMAGE_HEIGHT 0x806C
-#define GL_PACK_SKIP_IMAGES 0x806B
-#define GL_PROXY_TEXTURE_3D 0x8070
-#define GL_RESCALE_NORMAL 0x803A
-#define GL_SEPARATE_SPECULAR_COLOR 0x81FA
-#define GL_SINGLE_COLOR 0x81F9
-#define GL_SMOOTH_LINE_WIDTH_GRANULARITY 0x0B23
-#define GL_SMOOTH_LINE_WIDTH_RANGE 0x0B22
-#define GL_SMOOTH_POINT_SIZE_GRANULARITY 0x0B13
-#define GL_SMOOTH_POINT_SIZE_RANGE 0x0B12
-#define GL_TEXTURE_3D 0x806F
-#define GL_TEXTURE_BASE_LEVEL 0x813C
-#define GL_TEXTURE_BINDING_3D 0x806A
-#define GL_TEXTURE_DEPTH 0x8071
-#define GL_TEXTURE_MAX_LEVEL 0x813D
-#define GL_TEXTURE_MAX_LOD 0x813B
-#define GL_TEXTURE_MIN_LOD 0x813A
-#define GL_TEXTURE_WRAP_R 0x8072
-#define GL_UNPACK_IMAGE_HEIGHT 0x806E
-#define GL_UNPACK_SKIP_IMAGES 0x806D
-#define GL_UNSIGNED_BYTE_2_3_3_REV 0x8362
-#define GL_UNSIGNED_BYTE_3_3_2 0x8032
-#define GL_UNSIGNED_INT_10_10_10_2 0x8036
-#define GL_UNSIGNED_INT_2_10_10_10_REV 0x8368
-#define GL_UNSIGNED_INT_8_8_8_8 0x8035
-#define GL_UNSIGNED_INT_8_8_8_8_REV 0x8367
-#define GL_UNSIGNED_SHORT_1_5_5_5_REV 0x8366
-#define GL_UNSIGNED_SHORT_4_4_4_4 0x8033
-#define GL_UNSIGNED_SHORT_4_4_4_4_REV 0x8365
-#define GL_UNSIGNED_SHORT_5_5_5_1 0x8034
-#define GL_UNSIGNED_SHORT_5_6_5 0x8363
-#define GL_UNSIGNED_SHORT_5_6_5_REV 0x8364
-
 #ifndef GL_EXT_blend_minmax
 #define GL_EXT_blend_minmax 1
 extern void (CODEGEN_FUNCPTR *sf_ptrc_glBlendEquationEXT)(GLenum);
@@ -1069,19 +1030,6 @@ GLAPI void APIENTRY glTexCoordPointer(GLint, GLenum, GLsizei, const GLvoid *);
 GLAPI void APIENTRY glTexSubImage1D(GLenum, GLint, GLint, GLsizei, GLenum, GLenum, const GLvoid *);
 GLAPI void APIENTRY glTexSubImage2D(GLenum, GLint, GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, const GLvoid *);
 GLAPI void APIENTRY glVertexPointer(GLint, GLenum, GLsizei, const GLvoid *);
-
-extern void (CODEGEN_FUNCPTR *sf_ptrc_glBlendColor)(GLfloat, GLfloat, GLfloat, GLfloat);
-#define glBlendColor sf_ptrc_glBlendColor
-extern void (CODEGEN_FUNCPTR *sf_ptrc_glBlendEquation)(GLenum);
-#define glBlendEquation sf_ptrc_glBlendEquation
-extern void (CODEGEN_FUNCPTR *sf_ptrc_glCopyTexSubImage3D)(GLenum, GLint, GLint, GLint, GLint, GLint, GLint, GLsizei, GLsizei);
-#define glCopyTexSubImage3D sf_ptrc_glCopyTexSubImage3D
-extern void (CODEGEN_FUNCPTR *sf_ptrc_glDrawRangeElements)(GLenum, GLuint, GLuint, GLsizei, GLenum, const GLvoid *);
-#define glDrawRangeElements sf_ptrc_glDrawRangeElements
-extern void (CODEGEN_FUNCPTR *sf_ptrc_glTexImage3D)(GLenum, GLint, GLint, GLsizei, GLsizei, GLsizei, GLint, GLenum, GLenum, const GLvoid *);
-#define glTexImage3D sf_ptrc_glTexImage3D
-extern void (CODEGEN_FUNCPTR *sf_ptrc_glTexSubImage3D)(GLenum, GLint, GLint, GLint, GLint, GLsizei, GLsizei, GLsizei, GLenum, GLenum, const GLvoid *);
-#define glTexSubImage3D sf_ptrc_glTexSubImage3D
 
 enum sfogl_LoadStatus
 {

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -395,8 +395,8 @@ void GlContext::initialize()
         }
         else
         {
-            // Can't get the version number, assume 2.1
-            m_settings.majorVersion = 2;
+            // Can't get the version number, assume 1.1
+            m_settings.majorVersion = 1;
             m_settings.minorVersion = 1;
         }
     }

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -44,15 +44,11 @@ void ensureExtensionsInit(HDC deviceContext)
     static bool initialized = false;
     if (!initialized)
     {
-        int loaded = sfwgl_LoadFunctions(deviceContext);
-        if (loaded == sfwgl_LOAD_FAILED)
-        {
-            err() << "Failed to initialize WglExtensions" << std::endl;
-        }
-        else
-        {
-            initialized = true;
-        }
+        initialized = true;
+
+        // We don't check the return value since the extension
+        // flags are cleared even if loading fails
+        sfwgl_LoadFunctions(deviceContext);
     }
 }
 
@@ -207,8 +203,15 @@ void WglContext::setVerticalSyncEnabled(bool enabled)
     }
     else
     {
-        // wglSwapIntervalEXT not supported
-        err() << "Setting vertical sync not supported" << std::endl;
+        static bool warned = false;
+
+        if (!warned)
+        {
+            // wglSwapIntervalEXT not supported
+            err() << "Setting vertical sync not supported" << std::endl;
+
+            warned = true;
+        }
     }
 }
 
@@ -469,8 +472,8 @@ void WglContext::createContext(WglContext* shared, unsigned int bitsPerPixel, co
     // If wglCreateContextAttribsARB failed, use wglCreateContext
     if (!m_context)
     {
-        // set the context version to 2.1 (arbitrary) and disable flags
-        m_settings.majorVersion = 2;
+        // set the context version to 1.1 (arbitrary) and disable flags
+        m_settings.majorVersion = 1;
         m_settings.minorVersion = 1;
         m_settings.attributeFlags = ContextSettings::Default;
 


### PR DESCRIPTION
Prevents crashes on systems that can't provide a 1.2+ context such as Windows without a proper/functioning driver. People who can't be bothered with fixing the problem will still be able to use sfml-graphics while being limited to the functionality supported by 1.1. This was the behaviour before BlendModes was implemented.

http://en.sfml-dev.org/forums/index.php?topic=17793.0