### PR TITLE
Fixed getting relative mouse position on Unix

### DIFF
--- a/src/SFML/Window/Unix/InputImpl.cpp
+++ b/src/SFML/Window/Unix/InputImpl.cpp
@@ -315,7 +315,7 @@ Vector2i InputImpl::getMousePosition(const Window& relativeTo)
                 connection,
                 xcb_query_pointer(
                     connection,
-                    XCBDefaultRootWindow(connection)
+                    handle
                 ),
                 &error
             )


### PR DESCRIPTION
Fixes #860.

The handle argument was accidentally removed in c22987731384a7be75bf189a017cba0e4ee16610. :grin: