### PR TITLE
Fixed warning about switches

### DIFF
--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -42,7 +42,6 @@ namespace
     {
         switch (blendFactor)
         {
-            default:
             case sf::BlendMode::Zero:             return GL_ZERO;
             case sf::BlendMode::One:              return GL_ONE;
             case sf::BlendMode::SrcColor:         return GL_SRC_COLOR;
@@ -62,7 +61,6 @@ namespace
     {
         switch (blendEquation)
         {
-            default:
             case sf::BlendMode::Add:             return GLEXT_GL_FUNC_ADD;
             case sf::BlendMode::Subtract:        return GLEXT_GL_FUNC_SUBTRACT;
         }

--- a/src/SFML/Network/Http.cpp
+++ b/src/SFML/Network/Http.cpp
@@ -107,7 +107,6 @@ std::string Http::Request::prepare() const
     std::string method;
     switch (m_method)
     {
-        default:
         case Get:    method = "GET";    break;
         case Post:   method = "POST";   break;
         case Head:   method = "HEAD";   break;

--- a/src/SFML/Window/OSX/JoystickImpl.cpp
+++ b/src/SFML/Window/OSX/JoystickImpl.cpp
@@ -255,6 +255,7 @@ bool JoystickImpl::open(unsigned int index)
                     case kHIDUsage_GD_Rx: m_axis[Joystick::U] = element; break;
                     case kHIDUsage_GD_Ry: m_axis[Joystick::V] = element; break;
                     case kHIDUsage_GD_Rz: m_axis[Joystick::R] = element; break;
+                    default: break;
                     // kHIDUsage_GD_Vx, kHIDUsage_GD_Vy, kHIDUsage_GD_Vz are ignored.
                 }
                 break;


### PR DESCRIPTION
This patch silences warnings such as:

> warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]