### PR TITLE
Some more OpenGL stuff

### DIFF
--- a/include/SFML/Window/ContextSettings.hpp
+++ b/include/SFML/Window/ContextSettings.hpp
@@ -25,6 +25,11 @@
 #ifndef SFML_CONTEXTSETTINGS_HPP
 #define SFML_CONTEXTSETTINGS_HPP
 
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <string>
+
 
 namespace sf
 {
@@ -76,6 +81,8 @@ struct ContextSettings
     unsigned int majorVersion;      ///< Major number of the context version to create
     unsigned int minorVersion;      ///< Minor number of the context version to create
     Uint32       attributeFlags;    ///< The attribute flags to create the context with
+    std::string  vendorName;        ///< Name of the vendor of the OpenGL implementation
+    std::string  rendererName;      ///< Name of the OpenGL renderer implementation
 };
 
 } // namespace sf

--- a/src/SFML/Main/MainWin32.cpp
+++ b/src/SFML/Main/MainWin32.cpp
@@ -41,6 +41,13 @@
 
 #include <windows.h>
 
+// Inform the Nvidia/AMD driver that this SFML application should
+// make use of the more powerful discrete GPU
+extern "C"
+{
+__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
 
 extern int main(int argc, char* argv[]);
 

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -401,6 +401,13 @@ void GlContext::initialize()
         }
     }
 
+    // Fill in the vendor and renderer strings
+    const char* vendorName = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
+    m_settings.vendorName = vendorName ? vendorName : "Unknown Vendor";
+
+    const char* rendererName = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
+    m_settings.rendererName = rendererName ? rendererName : "Unknown Renderer";
+
     // 3.0 contexts only deprecate features, but do not remove them yet
     // 3.1 contexts remove features if ARB_compatibility is not present
     // 3.2+ contexts remove features only if a core profile is requested
@@ -472,6 +479,14 @@ void GlContext::initialize()
 void GlContext::checkSettings(const ContextSettings& requestedSettings)
 {
     // Perform checks to inform the user if they are getting a context they might not have expected
+
+    // Detect Microsoft's non-accelerated default implementation and warn
+    if ((m_settings.vendorName == "Microsoft Corporation") &&
+        (m_settings.rendererName == "GDI Generic"))
+    {
+        err() << "Warning: Detected \"Microsoft Corporation\" \"GDI Generic\"" << std::endl
+              << "The current OpenGL implementation is not hardware-accelerated" << std::endl;
+    }
 
     int version = m_settings.majorVersion * 10 + m_settings.minorVersion;
     int requestedVersion = requestedSettings.majorVersion * 10 + requestedSettings.minorVersion;


### PR DESCRIPTION
This pull request adds:
* Vendor and renderer strings to `sf::ContextSettings` so that the application developer can check them if they need to
* Adds an additional check for "Microsoft Corporation" and "GDI Generic" strings, just because Microsoft loves OpenGL :smirk:
* Adds `NvOptimusEnablement` export (as described [here](http://developer.download.nvidia.com/devzone/devcenter/gamegraphics/files/OptimusRenderingPolicies.pdf)) to sfml-main so that any application that links to it will export that symbol and tell the Nvidia driver to run the application using the discrete GPU (sfml-main is always static, so the symbol will always be exported by the application if it gets linked in)

This is kind of a knee-jerk response to all those threads that have been popping up on the forum recently that are 99% caused by users not knowing that they are running on the GDI implementation on Windows. With this, we can leave it up to the application developer to sort out their users' problems and not come to us straight away every time something mysteriously breaks.

It would be nice if this could get in for 2.3. It would save us (especially me) a lot of forum headaches :grin:.

@LaurentGomila, @mantognini, @eXpl0it3r, @TankOs, @Bromeon, @MarioLiebisch, @Sonkun feel free to review and provide prompt feedback :wink:.