### PR TITLE
Add unit tests for Rect.hpp

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SRCROOT "${PROJECT_SOURCE_DIR}/test/src")
 SET(SRC
     "${SRCROOT}/Main.cpp"
     "${SRCROOT}/Vector2.cpp"
+    "${SRCROOT}/Rect.cpp"
 )
 
 include_directories("${PROJECT_SOURCE_DIR}/include")

--- a/test/src/Rect.cpp
+++ b/test/src/Rect.cpp
@@ -1,0 +1,120 @@
+#include <SFML/Graphics/Rect.hpp>
+#include <SFML/System/Vector2.hpp>
+#include <catch.hpp>
+
+TEST_CASE("sf::Rect class")
+{
+    SECTION("Construction")
+    {
+        SECTION("Default constructor")
+        {
+            sf::IntRect rectangle;
+            CHECK(rectangle.left == 0);
+            CHECK(rectangle.top == 0);
+            CHECK(rectangle.width == 0);
+            CHECK(rectangle.height == 0);
+        }
+
+        SECTION("(left, top, width, height) constructor")
+        {
+            sf::IntRect rectangle(1, 2, 3, 4);
+            CHECK(rectangle.left == 1);
+            CHECK(rectangle.top == 2);
+            CHECK(rectangle.width == 3);
+            CHECK(rectangle.height == 4);
+        }
+
+        SECTION("(Vector2, Vector2) constructor")
+        {
+            sf::Vector2i position(1, 2);
+            sf::Vector2i dimension(3, 4);
+            sf::IntRect rectangle(position, dimension);
+
+            CHECK(rectangle.left == 1);
+            CHECK(rectangle.top == 2);
+            CHECK(rectangle.width == 3);
+            CHECK(rectangle.height == 4);
+        }
+
+        SECTION("Conversion constructor")
+        {
+            sf::FloatRect sourceRectangle(1.0f, 2.0f, 3.0f, 4.0f);
+            sf::IntRect rectangle(sourceRectangle);
+
+            CHECK(rectangle.left == static_cast<int>(sourceRectangle.left));
+            CHECK(rectangle.top == static_cast<int>(sourceRectangle.top));
+            CHECK(rectangle.width == static_cast<int>(sourceRectangle.width));
+            CHECK(rectangle.height == static_cast<int>(sourceRectangle.height));
+        }
+    }
+
+    SECTION("Containment")
+    {
+        SECTION("contains(x, y)")
+        {
+            sf::IntRect rectangle(0, 0, 10, 10);
+
+            CHECK(rectangle.contains(0, 0) == true);
+            CHECK(rectangle.contains(9, 0) == true);
+            CHECK(rectangle.contains(0, 9) == true);
+            CHECK(rectangle.contains(9, 9) == true);
+            CHECK(rectangle.contains(9, 10) == false);
+            CHECK(rectangle.contains(10, 9) == false);
+            CHECK(rectangle.contains(10, 10) == false);
+            CHECK(rectangle.contains(15, 15) == false);
+        }
+
+        SECTION("contains(Vector2)")
+        {
+            sf::IntRect rectangle(0, 0, 10, 10);
+
+            CHECK(rectangle.contains(sf::Vector2i(0, 0)) == true);
+            CHECK(rectangle.contains(sf::Vector2i(9, 0)) == true);
+            CHECK(rectangle.contains(sf::Vector2i(0, 9)) == true);
+            CHECK(rectangle.contains(sf::Vector2i(9, 9)) == true);
+            CHECK(rectangle.contains(sf::Vector2i(9, 10)) == false);
+            CHECK(rectangle.contains(sf::Vector2i(10, 9)) == false);
+            CHECK(rectangle.contains(sf::Vector2i(10, 10)) == false);
+            CHECK(rectangle.contains(sf::Vector2i(15, 15)) == false);
+        }
+    }
+
+    SECTION("Intersection")
+    {
+        SECTION("intersects(Rect)")
+        {
+            sf::IntRect rectangle(0, 0, 10, 10);
+            sf::IntRect intersectingRectangle(5, 5, 10, 10);
+            sf::IntRect nonIntersectingRectangle(-5, -5, 5, 5);
+
+            CHECK(rectangle.intersects(intersectingRectangle) == true);
+            CHECK(rectangle.intersects(nonIntersectingRectangle) == false);
+        }
+
+        SECTION("intersects(Rect, Rect)")
+        {
+            sf::IntRect rectangle(0, 0, 10, 10);
+            sf::IntRect intersectingRectangle(5, 5, 10, 10);
+            sf::IntRect nonIntersectingRectangle(-5, -5, 5, 5);
+            sf::IntRect intersectionResult;
+
+            CHECK(rectangle.intersects(intersectingRectangle, intersectionResult) == true);
+            CHECK(intersectionResult.top == 5);
+            CHECK(intersectionResult.left == 5);
+            CHECK(intersectionResult.width == 5);
+            CHECK(intersectionResult.height == 5);
+
+            CHECK(rectangle.intersects(nonIntersectingRectangle, intersectionResult) == false);
+        }
+    }
+
+    SECTION("Comparison operations")
+    {
+        sf::IntRect firstRectangle(1, 3, 2, 5);
+        sf::IntRect secondRectangle(1, 3, 2, 5);
+        sf::IntRect differentRectangle(3, 1, 5, 2);
+
+        CHECK(firstRectangle == secondRectangle);
+        CHECK(firstRectangle != differentRectangle);
+    }
+}


### PR DESCRIPTION
Added basic unit test coverage for Rect.hpp using IntRect, similar to the existing Vector2 tests. All constructors, methods, and operators are covered. There is an open issue to increase test coverage, #623.

I know the contribution guide (http://www.sfml-dev.org/contribute.php) says to target the master branch, but this feature branch hasn't been merged into master yet so I didn't think it appropriate.